### PR TITLE
Fixes boxing - Blaze global style

### DIFF
--- a/packages/alert/Alert.scss
+++ b/packages/alert/Alert.scss
@@ -1,2 +1,3 @@
+@import "../generics.shared";
 @import '~blaze/scss/components.alerts';
 @import '~blaze/scss/components.buttons';

--- a/packages/badge/Badge.scss
+++ b/packages/badge/Badge.scss
@@ -1,1 +1,2 @@
+@import "../generics.shared";
 @import "~blaze/scss/components.badges";

--- a/packages/button/Button.scss
+++ b/packages/button/Button.scss
@@ -1,1 +1,2 @@
+@import "../generics.shared";
 @import "~blaze/scss/components.buttons";

--- a/packages/card/Card.scss
+++ b/packages/card/Card.scss
@@ -1,1 +1,2 @@
+@import "../generics.shared";
 @import "~blaze/scss/components.cards";

--- a/packages/generics.shared.scss
+++ b/packages/generics.shared.scss
@@ -1,0 +1,9 @@
+* {
+  box-sizing: border-box;
+}
+
+* *,
+* *:before,
+* *:after {
+  box-sizing: inherit;
+}

--- a/packages/input/Input.scss
+++ b/packages/input/Input.scss
@@ -1,2 +1,3 @@
+@import "../generics.shared";
 @import "~blaze/scss/components.inputs";
 @import "~blaze/scss/utilities.sizes";

--- a/packages/modal/Modal.scss
+++ b/packages/modal/Modal.scss
@@ -1,2 +1,3 @@
+@import "../generics.shared";
 @import "~blaze/scss/components.overlays";
 @import "~blaze/scss/objects.modals";

--- a/packages/toggle/Toggle.scss
+++ b/packages/toggle/Toggle.scss
@@ -1,3 +1,2 @@
-@import "~blaze/scss/generics.global";
+@import "../generics.shared";
 @import "~blaze/scss/components.toggles";
-//@import "~blaze/scss/blaze";

--- a/packages/tooltip/Tooltip.scss
+++ b/packages/tooltip/Tooltip.scss
@@ -1,1 +1,2 @@
+@import "../generics.shared";
 @import '~blaze/scss/components.tooltips';


### PR DESCRIPTION
Introduces & uses **generics.shared.scss** which is based on **~blaze/scss/generics.global.scss** with small tweak to be working in shadow DOM.