### PR TITLE
Removal of all _props as generics are used

### DIFF
--- a/packages/alert/Alert.tsx
+++ b/packages/alert/Alert.tsx
@@ -12,7 +12,6 @@ interface AlertProps extends JSX.HTMLProps<HTMLElement | any> {
 }
 
 export class Alert extends Component<AlertProps> {
-  _props: AlertProps;
   static get is() { return 'bl-alert' }
   static get props() {
     return {

--- a/packages/badge/Badge.tsx
+++ b/packages/badge/Badge.tsx
@@ -10,7 +10,6 @@ interface BadgeProps extends JSX.HTMLProps<HTMLElement | any> {
 }
 
 export class Badge extends Component<BadgeProps> {
-  _props: BadgeProps;
   static get is() { return 'bl-badge' }
   static get props() {
     return {

--- a/packages/breadcrumb/Breadcrumb-item.tsx
+++ b/packages/breadcrumb/Breadcrumb-item.tsx
@@ -7,8 +7,6 @@ interface BreadcrumbItemProps extends JSX.HTMLProps<HTMLElement | any> {
   href?: string
 }
 export class BreadcrumbItem extends Component<BreadcrumbItemProps> {
-  _props: BreadcrumbItemProps;
-
   static get is() { return 'bl-breadcrumb-item' }
 
   static get props() {

--- a/packages/bubble/Bubble.tsx
+++ b/packages/bubble/Bubble.tsx
@@ -19,7 +19,6 @@ interface BubbleProps extends JSX.HTMLProps<HTMLElement | any> {
 }
 
 export class Bubble extends Component<BubbleProps> {
-  _props: BubbleProps;
   static get is() { return 'bl-bubble' }
   static get props() {
     return {

--- a/packages/drawer/Drawer.tsx
+++ b/packages/drawer/Drawer.tsx
@@ -17,8 +17,6 @@ interface DrawerProps extends JSX.HTMLProps<HTMLElement | any> {
 }
 
 export class Drawer extends Component<DrawerProps>{
-  _props: DrawerProps;
-
   static get is() { return 'bl-drawer' }
   static get props() {
     return {

--- a/packages/input/Input.tsx
+++ b/packages/input/Input.tsx
@@ -23,7 +23,6 @@ interface InputProps extends JSX.HTMLProps<HTMLInputElement | any> {
 }
 
 export class Input extends Component<InputProps> {
-  _props: InputProps;
   static get is() { return 'bl-input' }
   static get props() {
     return {

--- a/packages/link/Link.tsx
+++ b/packages/link/Link.tsx
@@ -21,8 +21,6 @@ interface LinkProps extends JSX.HTMLProps<Link | any> {
 }
 
 export class Link extends Component<LinkProps> {
-  _props: LinkProps;
-
   static get is() { return 'bl-link' }
 
   static get props() {

--- a/packages/modal/Modal.tsx
+++ b/packages/modal/Modal.tsx
@@ -9,7 +9,6 @@ interface ModalProps extends JSX.HTMLProps<HTMLElement | any> {
   onModalClose?: Function,
 }
 export class Modal extends Component<ModalProps> {
-  _props: ModalProps;
   static get is() { return 'bl-modal' }
   static get props() {
     return {

--- a/packages/nav/Nav-content.tsx
+++ b/packages/nav/Nav-content.tsx
@@ -6,8 +6,6 @@ interface NavContentProps extends JSX.HTMLProps<HTMLElement | any> {
   inline?: boolean,
 }
 export class NavContent extends Component<NavContentProps> {
-  _props: NavContentProps;
-
   static get is() { return 'bl-nav-content' }
   static get props() {
     return {

--- a/packages/nav/Nav-item.tsx
+++ b/packages/nav/Nav-item.tsx
@@ -10,8 +10,6 @@ interface NavItemProps extends JSX.HTMLProps<HTMLElement | any> {
   inline?: boolean,
 }
 export class NavItem extends Component<NavItemProps> {
-  _props: NavItemProps;
-
   static get is() { return 'bl-nav-item' }
   static get props() {
     return {

--- a/packages/overlay/Overlay.tsx
+++ b/packages/overlay/Overlay.tsx
@@ -10,7 +10,6 @@ interface OverlayProps extends JSX.HTMLProps<HTMLElement | any> {
 }
 
 export class Overlay extends Component<OverlayProps> {
-  _props: OverlayProps;
   static get is() { return 'bl-overlay' }
   static get props() {
     return {

--- a/packages/progress/Progress.tsx
+++ b/packages/progress/Progress.tsx
@@ -13,7 +13,6 @@ interface ProgressProps extends JSX.HTMLProps<HTMLElement | any> {
 }
 
 export class Progress extends Component<ProgressProps> {
-  _props: ProgressProps;
   static get is() { return 'bl-progress' }
   static get props() {
     return {

--- a/packages/range/Range.tsx
+++ b/packages/range/Range.tsx
@@ -10,7 +10,6 @@ interface RangeProps extends JSX.HTMLProps<HTMLInputElement | any> {
 }
 
 export class Range extends Component<RangeProps> {
-  _props: RangeProps;
   static get is() { return 'bl-range' }
   static get props() {
     return {

--- a/packages/toggle/Toggle.tsx
+++ b/packages/toggle/Toggle.tsx
@@ -11,7 +11,6 @@ export interface ToggleProps extends JSX.HTMLProps<HTMLInputElement | any> {
 }
 
 export class Toggle extends Component<ToggleProps> {
-  _props: ToggleProps;
   static get is(){ return 'bl-toggle'}
   static get props(){
     return {

--- a/packages/tooltip/Tooltip.tsx
+++ b/packages/tooltip/Tooltip.tsx
@@ -17,7 +17,6 @@ interface TooltipProps extends JSX.HTMLProps<HTMLElement | any> {
 }
 
 export class Tooltip extends Component<TooltipProps> {
-  _props: TooltipProps;
   static get is() { return 'bl-tooltip' }
   static get props() {
     return {

--- a/packages/tree/Tree-item.tsx
+++ b/packages/tree/Tree-item.tsx
@@ -6,8 +6,6 @@ interface TreeItemProps extends JSX.HTMLProps<HTMLElement | any> {
   isOpen?: boolean,
 }
 export class TreeItem extends Component<TreeItemProps> {
-  _props: TreeItemProps;
-
   static get is() { return 'bl-tree-item' }
 
   static get props() {


### PR DESCRIPTION
- all **_props** has been removed from all existing components as generics are being used there

@Hotell is it OK to proceed with this now or should we wait for something?