### PR TITLE
chore(alert): use explicit import

### DIFF
--- a/packages/alert/index.demo.tsx
+++ b/packages/alert/index.demo.tsx
@@ -1,5 +1,5 @@
 import { h, Component, prop, props, define } from 'skatejs';
-import { Alert } from './';
+import { Alert } from './index';
 import { Button } from '../button/Button';
 
 type DemoProps = {isOpen?: boolean};


### PR DESCRIPTION
as './' is interpreted as normal package and thus it use 'packages/alert/dist/main.js' as defined in package.json