### PR TITLE
refactor(calendar): init component logic & repair range fn & tests

### DIFF
--- a/packages/_helpers/definitions/events.ts
+++ b/packages/_helpers/definitions/events.ts
@@ -2,3 +2,6 @@
   export type FocusEvent = typeof HTMLElement.prototype.onfocus;
   export type BlurEvent = typeof HTMLElement.prototype.onblur;
   export type KeyupEvent = typeof HTMLElement.prototype.onkeyup;
+
+  export type CustomChangeHandler<T> = ( event: CustomChangeEvent<T> ) => any;
+  export type CustomChangeEvent<T> = CustomEvent & { detail: { value: T } };

--- a/packages/_helpers/index.ts
+++ b/packages/_helpers/index.ts
@@ -6,3 +6,5 @@ export * from './colorTypes';
 export * from './css';
 export * from './sizes';
 export * from './bore-h';
+export * from './buildFormatLocale';
+

--- a/packages/calendar/Calendar.test.tsx
+++ b/packages/calendar/Calendar.test.tsx
@@ -1,11 +1,12 @@
 import * as expect from 'expect';
 import * as isSameDay from 'date-fns/is_same_day';
 import * as parse from 'date-fns/parse';
-import { Calendar } from './';
+import { Calendar } from './index';
 import { CalendarButton } from './components/Button';
 
 import { h, mount, WrappedNode } from 'bore';
 import { emit } from 'skatejs';
+import { GenericEvents } from '../_helpers';
 
 describe( Calendar.is, () => {
 
@@ -194,7 +195,7 @@ describe( Calendar.is, () => {
 
         let changeTriggered = false;
         let selectedDate: Date;
-        const handleChange = ( e: CustomEvent ) => {
+        const handleChange = ( e: GenericEvents.CustomChangeEvent<Date> ) => {
           changeTriggered = true;
           selectedDate = e.detail.value;
         };

--- a/packages/calendar/Calendar.test.tsx
+++ b/packages/calendar/Calendar.test.tsx
@@ -1,5 +1,6 @@
 import * as expect from 'expect';
 import * as isSameDay from 'date-fns/is_same_day';
+import * as parse from 'date-fns/parse';
 import { Calendar } from './';
 import { CalendarButton } from './components/Button';
 
@@ -189,7 +190,7 @@ describe( Calendar.is, () => {
 
       it( `should emit onChange event with selected day value`, () => {
 
-        const expectedDate = new Date( '1987-12-09' );
+        const expectedDate = parse( '1987-12-09' );
 
         let changeTriggered = false;
         let selectedDate: Date;
@@ -201,17 +202,13 @@ describe( Calendar.is, () => {
         return mount(
           <bl-calendar
             events={{ dateChange: handleChange }}
-            selectedDate={new Date( '1987-12-22' )}
+            selectedDate={parse( '1987-12-22' )}
           />
         ).wait( ( element ) => {
 
           // existing day in month
           const oneDay = element.all( 'button:not(.c-calendar__control)' )[ 10 ].node as HTMLButtonElement;
-          console.log( 'expectedDate', expectedDate );
-          console.log( 'selectedDate', selectedDate);
           emit( oneDay, 'click' );
-          console.log( 'expectedDate', expectedDate );
-          console.log( 'selectedDate', selectedDate);
           expect( changeTriggered ).toBe( true );
           expect( isSameDay( expectedDate, selectedDate ) ).toBe( true );
 

--- a/packages/calendar/Calendar.test.tsx
+++ b/packages/calendar/Calendar.test.tsx
@@ -1,17 +1,184 @@
-import { Calendar } from './Calendar';
+import * as expect from 'expect';
+import * as isSameDay from 'date-fns/is_same_day';
+import { Calendar } from './';
+import { CalendarButton } from './components/Button';
 
 import { h, mount } from 'bore';
 
 describe( Calendar.is, () => {
 
-  it( 'should render', () => {
+  describe( `Custom element`, () => {
 
-    console.warn( 'Missing tests for Calendar!' );
+    it( `should be registered`, () => {
 
-    return mount(
-      <Calendar />
-    ).wait();
+      expect( customElements.get( Calendar.is ) ).toBe( Calendar );
+
+    });
+
+    it( `should render via JSX IntrinsicElement`, () => {
+
+      return mount(
+        <bl-calendar />
+      ).wait(( element ) => {
+
+        expect( element.node.localName ).toBe( Calendar.is );
+
+      });
+
+    });
+
+    it( `should render via JSX class`, () => {
+
+      return mount(
+        <Calendar />
+      ).wait(( element ) => {
+
+        expect( element.has( '.c-calendar' ) ).toBe( true );
+
+      });
+
+    });
+
+  });
+
+  describe( `API`, () => {
+
+    describe( `[selectedDate]`, () => {
+
+      it( `should automatically set today without selectedDate provided`, () => {
+
+        return mount(
+          <bl-calendar />
+        ).wait(( element ) => {
+
+          const today = new Date();
+          const calendar = element.node as Calendar;
+          expect( isSameDay( calendar.selectedDate, today ) ).toBe( true );
+
+        });
+
+      });
+
+      it( `should set year and month based on selectedDay`, () => {
+
+        return mount(
+          <bl-calendar selectedDate={new Date( '1987-12-22' )} />
+        ).wait(( element ) => {
+
+          const yearMonth = element.all( '.c-calendar__header' );
+          expect( yearMonth[ 0 ].node.innerHTML ).toBe( '1987' );
+          expect( yearMonth[ 1 ].node.innerHTML ).toBe( 'December' );
+
+        });
+
+      });
+
+    });
+
+    describe( `[weekStartsOn]`, () => {
+
+      it( `should set sunday as default`, () => {
+
+        return mount(
+          <bl-calendar />
+        ).wait(( element ) => {
+
+          const headDays = element.all( '.c-calendar__day' );
+          expect( headDays[ 0 ].node.innerHTML ).toBe( 'Su' );
+
+        });
+
+      });
+
+      it( `should set monday`, () => {
+
+        return mount(
+          <bl-calendar weekStartsOn="monday" />
+        ).wait(( element ) => {
+
+          const headDays = element.all( '.c-calendar__day' );
+          expect( headDays[ 0 ].node.innerHTML ).toBe( 'Mo' );
+
+        });
+
+      });
+
+      it( `should set sunday`, () => {
+
+        return mount(
+          <bl-calendar weekStartsOn="sunday" />
+        ).wait(( element ) => {
+
+          const headDays = element.all( '.c-calendar__day' );
+          expect( headDays[ 0 ].node.innerHTML ).toBe( 'Su' );
+
+        });
+
+      });
+
+    });
+
+    describe( `[i18n]`, () => {
+
+      const i18n = {
+        monthsFull: [
+          'Leden',
+          'Únor',
+          'Březen',
+          'Duben',
+          'Květen',
+          'Červen',
+          'Červenec',
+          'Srpen',
+          'Září',
+          'Říjen',
+          'Listopad',
+          'Prosinec'
+        ],
+        todayButtonText: 'DNES',
+        weekdays2char: [ 'Ne', 'Po', 'Út', 'St', 'Čt', 'Pá', 'So' ]
+      };
+
+
+      it( `should set months internationalized`, () => {
+
+        return mount(
+          <bl-calendar i18n={i18n} selectedDate={new Date( '1987-12-22' )} />
+        ).wait(( element ) => {
+
+          expect( element.all( '.c-calendar__header' )[ 1 ].node.innerHTML ).toBe( 'Prosinec' );
+
+        });
+
+      });
+
+      it( `should set weekdays internationalized`, () => {
+
+        return mount(
+          <bl-calendar i18n={i18n} />
+        ).wait(( element ) => {
+
+          expect( element.all( '.c-calendar__day' )[ 0 ].node.innerHTML ).toBe( 'Ne' );
+
+        });
+
+      });
+
+      it( `should set button text internationalized`, () => {
+
+        return mount(
+          <bl-calendar i18n={i18n} />
+        ).wait(( element ) => {
+
+          expect( element.one( CalendarButton.is ).node.innerHTML ).toBe( 'DNES' );
+
+        });
+
+      });
+
+    });
 
   });
 
 });
+

--- a/packages/calendar/Calendar.test.tsx
+++ b/packages/calendar/Calendar.test.tsx
@@ -209,6 +209,8 @@ describe( Calendar.is, () => {
           const oneDay = element.all( 'button:not(.c-calendar__control)' )[ 10 ].node as HTMLButtonElement;
           emit( oneDay, 'click' );
           expect( changeTriggered ).toBe( true );
+          console.log( 'expectedDate', expectedDate );
+          console.log( 'selectedDate', selectedDate);
           expect( isSameDay( expectedDate, selectedDate ) ).toBe( true );
 
         } );

--- a/packages/calendar/Calendar.test.tsx
+++ b/packages/calendar/Calendar.test.tsx
@@ -207,10 +207,12 @@ describe( Calendar.is, () => {
 
           // existing day in month
           const oneDay = element.all( 'button:not(.c-calendar__control)' )[ 10 ].node as HTMLButtonElement;
-          emit( oneDay, 'click' );
-          expect( changeTriggered ).toBe( true );
           console.log( 'expectedDate', expectedDate );
           console.log( 'selectedDate', selectedDate);
+          emit( oneDay, 'click' );
+          console.log( 'expectedDate', expectedDate );
+          console.log( 'selectedDate', selectedDate);
+          expect( changeTriggered ).toBe( true );
           expect( isSameDay( expectedDate, selectedDate ) ).toBe( true );
 
         } );

--- a/packages/calendar/Calendar.test.tsx
+++ b/packages/calendar/Calendar.test.tsx
@@ -3,7 +3,8 @@ import * as isSameDay from 'date-fns/is_same_day';
 import { Calendar } from './';
 import { CalendarButton } from './components/Button';
 
-import { h, mount } from 'bore';
+import { h, mount, WrappedNode } from 'bore';
+import { emit } from 'skatejs';
 
 describe( Calendar.is, () => {
 
@@ -13,33 +14,33 @@ describe( Calendar.is, () => {
 
       expect( customElements.get( Calendar.is ) ).toBe( Calendar );
 
-    });
+    } );
 
     it( `should render via JSX IntrinsicElement`, () => {
 
       return mount(
         <bl-calendar />
-      ).wait(( element ) => {
+      ).wait( ( element ) => {
 
         expect( element.node.localName ).toBe( Calendar.is );
 
-      });
+      } );
 
-    });
+    } );
 
     it( `should render via JSX class`, () => {
 
       return mount(
         <Calendar />
-      ).wait(( element ) => {
+      ).wait( ( element ) => {
 
         expect( element.has( '.c-calendar' ) ).toBe( true );
 
-      });
+      } );
 
-    });
+    } );
 
-  });
+  } );
 
   describe( `API`, () => {
 
@@ -49,31 +50,39 @@ describe( Calendar.is, () => {
 
         return mount(
           <bl-calendar />
-        ).wait(( element ) => {
+        ).wait( ( element ) => {
 
           const today = new Date();
           const calendar = element.node as Calendar;
           expect( isSameDay( calendar.selectedDate, today ) ).toBe( true );
 
-        });
+        } );
 
-      });
+      } );
+
+      it( `should set selectedDate via attribute`, () => {
+
+        return mount(
+          <bl-calendar attrs={{'selected-date': '1987-12-22'}}/>
+        ).wait( checkCorrectlySetDateFromProps );
+
+      } );
 
       it( `should set year and month based on selectedDay`, () => {
 
         return mount(
-          <bl-calendar selectedDate={new Date( '1987-12-22' )} />
-        ).wait(( element ) => {
+          <bl-calendar selectedDate={new Date( '1987-12-22' )}/>
+        ).wait( checkCorrectlySetDateFromProps );
 
-          const yearMonth = element.all( '.c-calendar__header' );
-          expect( yearMonth[ 0 ].node.innerHTML ).toBe( '1987' );
-          expect( yearMonth[ 1 ].node.innerHTML ).toBe( 'December' );
+      } );
 
-        });
+      function checkCorrectlySetDateFromProps( element: WrappedNode ) {
+        const yearMonth = element.all( '.c-calendar__header' );
+        expect( yearMonth[ 0 ].node.innerHTML ).toBe( '1987' );
+        expect( yearMonth[ 1 ].node.innerHTML ).toBe( 'December' );
+      }
 
-      });
-
-    });
+    } );
 
     describe( `[weekStartsOn]`, () => {
 
@@ -81,42 +90,40 @@ describe( Calendar.is, () => {
 
         return mount(
           <bl-calendar />
-        ).wait(( element ) => {
+        ).wait( checkWeekStarts.bind( null, 'Su' ) );
 
-          const headDays = element.all( '.c-calendar__day' );
-          expect( headDays[ 0 ].node.innerHTML ).toBe( 'Su' );
-
-        });
-
-      });
+      } );
 
       it( `should set monday`, () => {
 
         return mount(
-          <bl-calendar weekStartsOn="monday" />
-        ).wait(( element ) => {
+          <bl-calendar weekStartsOn="monday"/>
+        ).wait( checkWeekStarts.bind( null, 'Mo' ) );
 
-          const headDays = element.all( '.c-calendar__day' );
-          expect( headDays[ 0 ].node.innerHTML ).toBe( 'Mo' );
+      } );
 
-        });
+      it( `should set monday via attribute`, () => {
 
-      });
+        return mount(
+          <bl-calendar attrs={{'week-starts-on': 'monday'}}/>
+        ).wait( checkWeekStarts.bind( null, 'Mo' ) );
+
+      } );
 
       it( `should set sunday`, () => {
 
         return mount(
-          <bl-calendar weekStartsOn="sunday" />
-        ).wait(( element ) => {
+          <bl-calendar weekStartsOn="sunday"/>
+        ).wait( checkWeekStarts.bind( null, 'Su' ) );
 
-          const headDays = element.all( '.c-calendar__day' );
-          expect( headDays[ 0 ].node.innerHTML ).toBe( 'Su' );
+      } );
 
-        });
+      function checkWeekStarts( startDay: string, element: WrappedNode ) {
+        const headDays = element.all( '.c-calendar__day' );
+        expect( headDays[ 0 ].node.innerHTML ).toBe( startDay );
+      }
 
-      });
-
-    });
+    } );
 
     describe( `[i18n]`, () => {
 
@@ -143,42 +150,74 @@ describe( Calendar.is, () => {
       it( `should set months internationalized`, () => {
 
         return mount(
-          <bl-calendar i18n={i18n} selectedDate={new Date( '1987-12-22' )} />
-        ).wait(( element ) => {
+          <bl-calendar i18n={i18n} selectedDate={new Date( '1987-12-22' )}/>
+        ).wait( ( element ) => {
 
           expect( element.all( '.c-calendar__header' )[ 1 ].node.innerHTML ).toBe( 'Prosinec' );
 
-        });
+        } );
 
-      });
+      } );
 
       it( `should set weekdays internationalized`, () => {
 
         return mount(
-          <bl-calendar i18n={i18n} />
-        ).wait(( element ) => {
+          <bl-calendar i18n={i18n}/>
+        ).wait( ( element ) => {
 
           expect( element.all( '.c-calendar__day' )[ 0 ].node.innerHTML ).toBe( 'Ne' );
 
-        });
+        } );
 
-      });
+      } );
 
       it( `should set button text internationalized`, () => {
 
         return mount(
-          <bl-calendar i18n={i18n} />
-        ).wait(( element ) => {
+          <bl-calendar i18n={i18n}/>
+        ).wait( ( element ) => {
 
           expect( element.one( CalendarButton.is ).node.innerHTML ).toBe( 'DNES' );
 
-        });
+        } );
 
-      });
+      } );
 
-    });
+    } );
 
-  });
+    describe( `(dateChange)`, () => {
 
-});
+      it( `should emit onChange event with selected day value`, () => {
+
+        const expectedDate = new Date( '1987-12-09' );
+
+        let changeTriggered = false;
+        let selectedDate: Date;
+        const handleChange = ( e: CustomEvent ) => {
+          changeTriggered = true;
+          selectedDate = e.detail.value;
+        };
+
+        return mount(
+          <bl-calendar
+            events={{ dateChange: handleChange }}
+            selectedDate={new Date( '1987-12-22' )}
+          />
+        ).wait( ( element ) => {
+
+          // existing day in month
+          const oneDay = element.all( 'button:not(.c-calendar__control)' )[ 10 ].node as HTMLButtonElement;
+          emit( oneDay, 'click' );
+          expect( changeTriggered ).toBe( true );
+          expect( isSameDay( expectedDate, selectedDate ) ).toBe( true );
+
+        } );
+
+      } );
+
+    } );
+
+  } );
+
+} );
 

--- a/packages/calendar/Calendar.test.tsx
+++ b/packages/calendar/Calendar.test.tsx
@@ -220,4 +220,3 @@ describe( Calendar.is, () => {
   } );
 
 } );
-

--- a/packages/calendar/Calendar.tsx
+++ b/packages/calendar/Calendar.tsx
@@ -76,7 +76,8 @@ export class Calendar extends Component<CalendarProps> {
         },
         default: WEEK_STARTS_ON
       } ),
-      todayButtonText: prop.string()
+      todayButtonText: prop.string(),
+      i18n: prop.object(),
     };
   }
 

--- a/packages/calendar/Calendar.tsx
+++ b/packages/calendar/Calendar.tsx
@@ -15,6 +15,7 @@ import { CalendarButton } from './components/Button';
 
 const BUTTON_TODAY = 'TODAY';
 const WEEK_STARTS_ON = 'sunday';
+const DAYS_IN_MATRIX = 41;
 
 type WeekStart = 'sunday' | 'monday';
 
@@ -47,7 +48,7 @@ declare global {
   namespace JSX {
     interface IntrinsicElements {
       'bl-calendar': GenericTypes.IntrinsicCustomElement<CalendarProps>
-      & GenericTypes.IntrinsicBoreElement<Attrs, Events>
+        & GenericTypes.IntrinsicBoreElement<Attrs, Events>
     }
   }
 }
@@ -68,13 +69,13 @@ export class Calendar extends Component<CalendarProps> {
         deserialize( value: string ) {
           return parse( value );
         }
-      }),
+      } ),
       weekStartsOn: prop.string( {
         attribute: {
           source: true
         },
         default: WEEK_STARTS_ON
-      }),
+      } ),
       todayButtonText: prop.string()
     };
   }
@@ -85,8 +86,8 @@ export class Calendar extends Component<CalendarProps> {
     };
   }
 
-  static range( n: Number ) {
-    return Array.from( { length: n } as any, ( value: number, key: number ) => key );
+  static range( count: number ): number[] {
+    return Array.from( { length: count }, ( value: number, key: number ) => key );
   }
 
   selectedDate: Date;
@@ -98,8 +99,7 @@ export class Calendar extends Component<CalendarProps> {
   private year: number;
   private month: number;
   private days: Date[] = [];
-  private rows = Calendar.range( 6 );
-  private cols = Calendar.range( 7 );
+  private daysMatrix = Calendar.range( DAYS_IN_MATRIX );
 
   constructor() {
     super();
@@ -161,13 +161,13 @@ export class Calendar extends Component<CalendarProps> {
 
     props( this, {
       selectedDate: date
-    });
+    } );
 
     emit( this, Calendar.events.DATE_CHANGE, {
       detail: {
         value: this.selectedDate
       }
-    });
+    } );
   }
 
   renderCallback() {
@@ -175,7 +175,7 @@ export class Calendar extends Component<CalendarProps> {
     const { year, month, selectedDate } = this;
 
     // create date elements
-    const days = this.days.map(( day ) => {
+    const days = this.days.map( ( day ) => {
       const className = css(
         'c-calendar__date',
         {
@@ -185,12 +185,12 @@ export class Calendar extends Component<CalendarProps> {
         }
       );
       return <button class={className} onClick={this.setDateHandler( day )}>{getDate( day )}</button>;
-    });
+    } );
 
     // create weekDays elements
-    const weekDays = this.days.filter(( day, index ) =>
-      index < 7 ).map(( day ) =>
-        <div class="c-calendar__day">{this.format( day, 'dd' )}</div> );
+    const weekDays = this.days.filter( ( day, index ) =>
+    index < 7 ).map( ( day ) =>
+      <div class="c-calendar__day">{this.format( day, 'dd' )}</div> );
 
     return [
       <style>{styles}</style>,
@@ -233,22 +233,20 @@ export class Calendar extends Component<CalendarProps> {
 
   private initDays() {
     const date = new Date( this.year, this.month );
-    const days: Date[] = [];
-    let currentDate = startOfWeek( date,
+    const firstDay = startOfWeek( date,
       {
         weekStartsOn: this.weekStartsOn === WEEK_STARTS_ON
           ? 0
           : 1
-      });
+      } );
 
-    this.rows.forEach(() => {
-      this.cols.forEach(() => {
-        days.push( currentDate );
-        currentDate = addDays( currentDate, 1 );
-      });
-    });
+    const days: Date[] = this.daysMatrix.reduce( ( acc: Date[] ) => {
+      const lastDate = acc[ acc.length - 1 ];
+      const nextDate = addDays( lastDate, 1 );
+      return [ ...acc, nextDate ];
+    }, [ firstDay ] );
 
-    this.days = [ ...Array().concat( days ) ];
+    this.days = [ ...days ];
 
   }
 

--- a/packages/calendar/index.demo.tsx
+++ b/packages/calendar/index.demo.tsx
@@ -1,5 +1,6 @@
 import { h, Component, prop } from 'skatejs';
-import { Calendar, CalendarChangeEvent } from './index';
+import { Calendar } from './index';
+import { CustomChangeEvent } from '../_helpers/definitions/events';
 
 export class Demo extends Component<void> {
   static get is() { return 'bl-calendar-demo'; }
@@ -54,8 +55,8 @@ export class Demo extends Component<void> {
       </fieldset>
     ];
   }
-  private dateChangeHandler( event: CalendarChangeEvent ) {
-    this.selectedDate = event.detail.date;
+  private dateChangeHandler( event: CustomChangeEvent<Date> ) {
+    this.selectedDate = event.detail.value;
   }
 }
 

--- a/packages/calendar/index.demo.tsx
+++ b/packages/calendar/index.demo.tsx
@@ -43,7 +43,7 @@ export class Demo extends Component<void> {
       <fieldset>
         <legend>{Calendar.is}</legend>
         <span>Selected date: {this.selectedDate}</span>
-        {/*<Calendar selectedDate={this.selectedDate} onDateChange={this.dateChangeHandler} />*/}
+        <Calendar selectedDate={this.selectedDate} onDateChange={this.dateChangeHandler} />
         <h4>Internationalized calendar (Czech)</h4>
         <Calendar
           selectedDate={this.selectedDate}

--- a/packages/calendar/index.demo.tsx
+++ b/packages/calendar/index.demo.tsx
@@ -1,7 +1,5 @@
 import { h, Component, prop } from 'skatejs';
-import { Calendar, CalendarChangeEvent } from './Calendar';
-
-
+import { Calendar, CalendarChangeEvent } from './index';
 
 export class Demo extends Component<void> {
   static get is() { return 'bl-calendar-demo'; }
@@ -18,7 +16,7 @@ export class Demo extends Component<void> {
       monthsFull: [
         'Leden',
         'Únor',
-        'Březěn',
+        'Březen',
         'Duben',
         'Květen',
         'Červen',
@@ -45,13 +43,12 @@ export class Demo extends Component<void> {
       <fieldset>
         <legend>{Calendar.is}</legend>
         <span>Selected date: {this.selectedDate}</span>
-        <Calendar selectedDate={this.selectedDate} onDateChange={this.dateChangeHandler} />
+        {/*<Calendar selectedDate={this.selectedDate} onDateChange={this.dateChangeHandler} />*/}
         <h4>Internationalized calendar (Czech)</h4>
         <Calendar
           selectedDate={this.selectedDate}
           onDateChange={this.dateChangeHandler}
           i18n={this.i18n.cs}
-          weekStartsOn={'monday'}
         />
       </fieldset>
     ];

--- a/packages/calendar/index.demo.tsx
+++ b/packages/calendar/index.demo.tsx
@@ -49,6 +49,7 @@ export class Demo extends Component<void> {
           selectedDate={this.selectedDate}
           onDateChange={this.dateChangeHandler}
           i18n={this.i18n.cs}
+          weekStartsOn={'monday'}
         />
       </fieldset>
     ];

--- a/packages/calendar/index.demo.tsx
+++ b/packages/calendar/index.demo.tsx
@@ -1,6 +1,6 @@
 import { h, Component, prop } from 'skatejs';
 import { Calendar } from './index';
-import { CustomChangeEvent } from '../_helpers/definitions/events';
+import { GenericEvents } from '../_helpers';
 
 export class Demo extends Component<void> {
   static get is() { return 'bl-calendar-demo'; }
@@ -55,7 +55,7 @@ export class Demo extends Component<void> {
       </fieldset>
     ];
   }
-  private dateChangeHandler( event: CustomChangeEvent<Date> ) {
+  private dateChangeHandler( event: GenericEvents.CustomChangeEvent<Date> ) {
     this.selectedDate = event.detail.value;
   }
 }

--- a/packages/calendar/index.ts
+++ b/packages/calendar/index.ts
@@ -1,5 +1,5 @@
 import { define } from 'skatejs';
 import { Calendar } from './Calendar';
 
-export { Calendar, CalendarChangeEvent } from './Calendar';
+export { Calendar } from './Calendar';
 define( Calendar );

--- a/packages/calendar/index.ts
+++ b/packages/calendar/index.ts
@@ -1,1 +1,5 @@
-import './Calendar';
+import { define } from 'skatejs';
+import { Calendar } from './Calendar';
+
+export { Calendar, CalendarChangeEvent } from './Calendar';
+define( Calendar );


### PR DESCRIPTION
affects: bl-calendar

Some notes:
- month and year must be defined in `prop()` because we need to rerender after any change
  - I tried to use `props(...)`, but I don't wanna have year and month in type `Props` because I can't have public interface for setting this 
- I replaced setter of `selectedDate` to use `props(...)`
- new tests including test of i18n