### PR TITLE
refactor(helpers): Change event naming to splitted handler and event

### DIFF
--- a/packages/_helpers/definitions/events.ts
+++ b/packages/_helpers/definitions/events.ts
@@ -1,7 +1,11 @@
-  export type ClickEvent = typeof HTMLElement.prototype.onclick;
-  export type FocusEvent = typeof HTMLElement.prototype.onfocus;
-  export type BlurEvent = typeof HTMLElement.prototype.onblur;
-  export type KeyupEvent = typeof HTMLElement.prototype.onkeyup;
+export type ClickHandler = ( event: ClickEvent ) => any;
+export type ClickEvent = typeof HTMLElement.prototype.onclick;
+export type FocusHandler = ( event: FocusEvent ) => any;
+export type FocusEvent = typeof HTMLElement.prototype.onfocus;
+export type BlurHandler = ( event: BlurEvent ) => any;
+export type BlurEvent = typeof HTMLElement.prototype.onblur;
+export type KeyupHandler = ( event: KeyupEvent ) => any;
+export type KeyupEvent= typeof HTMLElement.prototype.onkeyup;
 
-  export type CustomChangeHandler<T> = ( event: CustomChangeEvent<T> ) => any;
-  export type CustomChangeEvent<T> = CustomEvent & { detail: { value: T } };
+export type CustomChangeHandler<T> = ( event: CustomChangeEvent<T> ) => any;
+export type CustomChangeEvent<T> = CustomEvent & { detail: { value: T } };

--- a/packages/_helpers/definitions/events.ts
+++ b/packages/_helpers/definitions/events.ts
@@ -1,11 +1,7 @@
-export type ClickHandler = ( event: ClickEvent ) => any;
-export type ClickEvent = typeof HTMLElement.prototype.onclick;
-export type FocusHandler = ( event: FocusEvent ) => any;
-export type FocusEvent = typeof HTMLElement.prototype.onfocus;
-export type BlurHandler = ( event: BlurEvent ) => any;
-export type BlurEvent = typeof HTMLElement.prototype.onblur;
-export type KeyupHandler = ( event: KeyupEvent ) => any;
-export type KeyupEvent= typeof HTMLElement.prototype.onkeyup;
+export type ClickHandler = typeof HTMLElement.prototype.onclick;
+export type FocusHandler = typeof HTMLElement.prototype.onfocus;
+export type BlurHandler = typeof HTMLElement.prototype.onblur;
+export type KeyupHandler = typeof HTMLElement.prototype.onkeyup;
 
 export type CustomChangeHandler<T> = ( event: CustomChangeEvent<T> ) => any;
 export type CustomChangeEvent<T> = CustomEvent & { detail: { value: T } };

--- a/packages/button/Button.test.tsx
+++ b/packages/button/Button.test.tsx
@@ -3,7 +3,6 @@ import { h, mount } from 'bore';
 import { emit } from 'skatejs';
 
 import { Button } from './index';
-import { ClickEvent } from '../_helpers/definitions/events';
 
 describe( Button.is, () => {
 
@@ -49,7 +48,7 @@ describe( Button.is, () => {
       it( `should handle click`, () => {
 
         let clickTriggered = false;
-        const handleClick = ( e: ClickEvent ) => { clickTriggered = true; };
+        const handleClick = ( e: MouseEvent ) => { clickTriggered = true; };
 
         return mount( <bl-button events={{ click: handleClick }}>Click me</bl-button> )
           .wait(( element ) => {

--- a/packages/button/Button.test.tsx
+++ b/packages/button/Button.test.tsx
@@ -3,6 +3,7 @@ import { h, mount } from 'bore';
 import { emit } from 'skatejs';
 
 import { Button } from './index';
+import { ClickEvent } from '../_helpers/definitions/events';
 
 describe( Button.is, () => {
 
@@ -48,7 +49,7 @@ describe( Button.is, () => {
       it( `should handle click`, () => {
 
         let clickTriggered = false;
-        const handleClick = ( e: MouseEvent ) => { clickTriggered = true; };
+        const handleClick = ( e: ClickEvent ) => { clickTriggered = true; };
 
         return mount( <bl-button events={{ click: handleClick }}>Click me</bl-button> )
           .wait(( element ) => {

--- a/packages/button/Button.tsx
+++ b/packages/button/Button.tsx
@@ -24,7 +24,7 @@ export type Events = {
   click?: GenericEvents.ClickHandler,
 };
 export type EventHandlers = {
-  onClick?: GenericEvents.ClickEvent,
+  onClick?: GenericEvents.ClickHandler,
 };
 
 declare global {

--- a/packages/button/Button.tsx
+++ b/packages/button/Button.tsx
@@ -21,7 +21,7 @@ export type Props = {
 };
 
 export type Events = {
-  click?: GenericEvents.ClickEvent,
+  click?: GenericEvents.ClickHandler,
 };
 export type EventHandlers = {
   onClick?: GenericEvents.ClickEvent,

--- a/packages/button/index.demo.tsx
+++ b/packages/button/index.demo.tsx
@@ -55,7 +55,7 @@ export class Demo extends Component<DemoProps> {
   }
 
   private addLogEntry( entry: string ) {
-    return ( ev: Event ) => {
+    return ( ev: MouseEvent ) => {
       props( this, { logger: [ ...this.logger, `${entry} - ${this.logger.length}` ] });
     };
   }

--- a/packages/input/Input.tsx
+++ b/packages/input/Input.tsx
@@ -23,9 +23,9 @@ type EventProps = {
   onChange?: ( ev: CustomEvent ) => void,
 };
 type Events = {
-  keyup?: GenericEvents.KeyupEvent,
-  focus?: GenericEvents.FocusEvent,
-  blur?: GenericEvents.BlurEvent,
+  keyup?: GenericEvents.KeyupHandler,
+  focus?: GenericEvents.FocusHandler,
+  blur?: GenericEvents.BlurHandler,
   change?: ( ev: CustomEvent ) => void,
 };
 type Props = {

--- a/packages/input/Input.tsx
+++ b/packages/input/Input.tsx
@@ -17,9 +17,9 @@ type TypesType = {
 
 type InputProps = Props & EventProps;
 type EventProps = {
-  onKeyup?: GenericEvents.KeyupEvent,
-  onFocus?: GenericEvents.FocusEvent,
-  onBlur?: GenericEvents.BlurEvent,
+  onKeyup?: GenericEvents.KeyupHandler,
+  onFocus?: GenericEvents.FocusHandler,
+  onBlur?: GenericEvents.BlurHandler,
   onChange?: ( ev: CustomEvent ) => void,
 };
 type Events = {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Change naming #172 


**What is the new behavior?**
Event naming was splitted to separate handlers and events.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
