### PR TITLE
feat(toggle): add onChange emit when checked value changed

### DIFF
--- a/packages/toggle/Toggle.test.tsx
+++ b/packages/toggle/Toggle.test.tsx
@@ -1,17 +1,153 @@
-import { Toggle } from './Toggle';
-
-import { h, mount } from 'bore';
+import * as expect from 'expect';
+import { h, mount, WrappedNode } from 'bore';
+import { emit } from 'skatejs';
+import { GenericEvents } from '../_helpers';
+import { Toggle } from './index';
 
 describe( Toggle.is, () => {
 
-  it( 'should render', () => {
+  describe( `Custom element`, () => {
 
-    console.warn( 'Missing tests for Toggle!' );
+    it( `should be registered`, () => {
 
-    return mount(
-      <Toggle />
-    ).wait();
+      expect( customElements.get( Toggle.is ) ).toBe( Toggle );
+
+    } );
+
+    it( `should render via JSX IntrinsicElement`, () => {
+
+      return mount(
+        <bl-toggle />
+      ).wait(( element ) => {
+
+        expect( element.node.localName ).toBe( Toggle.is );
+
+      } );
+
+    } );
+
+    it( `should render via JSX class`, () => {
+
+      return mount(
+        <Toggle />
+      ).wait(( element ) => {
+
+        expect( element.has( '.c-toggle' ) ).toBe( true );
+
+      } );
+
+    } );
 
   } );
+
+  describe( `API`, () => {
+
+    describe( `[disabled]`, () => {
+
+      it( `should set disabled state`, () => {
+
+        return mount(
+          <bl-toggle disabled />
+        ).wait( checkDisabled );
+
+      } );
+
+      it( `should set disabled state via attribute`, () => {
+
+        return mount(
+          <bl-toggle attrs={{ 'disabled': true }} />
+        ).wait( checkDisabled );
+
+      } );
+
+      function checkDisabled( element: WrappedNode ) {
+        const input: Partial<HTMLInputElement> = element.one( 'input' ).node;
+        expect( input.hasAttribute( 'disabled' ) ).toBe( true );
+      }
+
+    } );
+
+  } );
+
+  describe( `[color]`, () => {
+
+    it( `should set color`, () => {
+
+      return mount(
+        <bl-toggle color="warning" />
+      ).wait( checkColor );
+
+    } );
+
+    it( `should set color via attribute`, () => {
+
+      return mount(
+        <bl-toggle attrs={{ 'color': 'warning' }} />
+      ).wait( checkColor );
+
+    } );
+
+    function checkColor( element: WrappedNode ) {
+      const label: Partial<HTMLInputElement> = element.one( 'label' ).node;
+      expect( label.getAttribute( 'class' ) ).toContain( 'warning' );
+    }
+
+  } );
+
+  describe( `[checked]`, () => {
+
+    it( `should set checked`, () => {
+
+      return mount(
+        <bl-toggle checked />
+      ).wait( checkChecked );
+
+    } );
+
+    it( `should set checked via attribute`, () => {
+
+      return mount(
+        <bl-toggle attrs={{ 'checked': true }} />
+      ).wait( checkChecked );
+
+    } );
+
+    function checkChecked( element: WrappedNode ) {
+      const input: Partial<HTMLInputElement> = element.one( 'input' ).node;
+      expect( input.checked ).toBe( true );
+    }
+
+  } );
+
+  describe( `(change)`, () => {
+
+    it( `should emit onChange event with new value`, () => {
+
+      let changeTriggered = false;
+      let labelChecked = false;
+      const handleChange = ( e: GenericEvents.CustomChangeEvent<string> ) => {
+        changeTriggered = true;
+        labelChecked = e.detail.value;
+      };
+
+      return mount(
+        <bl-toggle
+          events={{ change: handleChange }}
+          checked={labelChecked}
+        />
+      ).wait(( element ) => {
+
+        // existing day in month
+        const input = element.one( 'input' ).node as HTMLLabelElement;
+        emit( input, 'change' );
+        expect( changeTriggered ).toBe( true );
+        expect( labelChecked ).toBe( true );
+
+      } );
+
+    } );
+
+  } );
+
 
 } );

--- a/packages/toggle/Toggle.test.tsx
+++ b/packages/toggle/Toggle.test.tsx
@@ -89,7 +89,7 @@ describe( Toggle.is, () => {
 
     function checkColor( element: WrappedNode ) {
       const label: Partial<HTMLInputElement> = element.one( 'label' ).node;
-      expect( label.getAttribute( 'class' ) ).toContain( 'warning' );
+      expect( label.classList.contains( 'c-toggle--warning' ) ).toBe( true );
     }
 
   } );

--- a/packages/toggle/Toggle.tsx
+++ b/packages/toggle/Toggle.tsx
@@ -1,13 +1,27 @@
 import styles from './Toggle.scss';
-import { h, Component, prop, props } from 'skatejs';
+import { h, Component, prop, props, emit } from 'skatejs';
 import { ColorType, cssClassForColorType } from '../_helpers/colorTypes';
-import { css } from '../_helpers/css';
+import { css, GenericTypes, GenericEvents } from '../_helpers/index';
 
-
-export interface ToggleProps {
+type ToggleProps = Props & EventProps;
+type EventProps = {
+  onChange?: GenericEvents.CustomChangeHandler<string>,
+};
+type Events = {
+  change?: GenericEvents.CustomChangeHandler<string>,
+};
+type Props = {
   disabled?: boolean,
   checked?: boolean,
   color?: ColorType,
+};
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'bl-toggle': GenericTypes.IntrinsicCustomElement<ToggleProps> & GenericTypes.IntrinsicBoreElement<Props, Events>
+    }
+  }
 }
 
 export class Toggle extends Component<ToggleProps> {
@@ -23,6 +37,11 @@ export class Toggle extends Component<ToggleProps> {
       color: prop.string( {
         attribute: true
       } )
+    };
+  }
+  static get events() {
+    return {
+      CHANGE: 'change'
     };
   }
   disabled = false;
@@ -54,10 +73,13 @@ export class Toggle extends Component<ToggleProps> {
       </label>
     ];
   }
-  private handleChecked( e?: Event ) {
+  private handleChecked( event: Event ) {
+    event.stopPropagation();
     props( this, { checked: !this.checked } );
+    emit( this, Toggle.events.CHANGE, {
+      detail: {
+        value: this.checked
+      }
+    } );
   }
 }
-
-
-customElements.define( Toggle.is, Toggle );

--- a/packages/toggle/index.demo.tsx
+++ b/packages/toggle/index.demo.tsx
@@ -1,8 +1,20 @@
 import { h, Component } from 'skatejs';
 import { Toggle } from './Toggle';
+import { GenericEvents } from '../_helpers/index';
 
 class Demo extends Component<void> {
   static get is() { return 'bl-toggle-demo'; };
+  toggleChecked = false;
+
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind( this );
+  }
+
+  handleChange = ( event: GenericEvents.CustomChangeEvent<string> ) => {
+    this.toggleChecked = event.detail.value;
+    console.log( 'Toggle: onChange triggered with value: ', event.detail.value );
+  }
 
   renderCallback() {
     return [
@@ -13,6 +25,7 @@ class Demo extends Component<void> {
         <div>
           <Toggle checked={true} color="brand">Yo mama</Toggle>
           <Toggle disabled>Yo mama</Toggle>
+          <Toggle checked={this.toggleChecked} onChange={this.handleChange}>Toggle on-change</Toggle>
         </div>
 
       </fieldset>

--- a/packages/toggle/index.ts
+++ b/packages/toggle/index.ts
@@ -1,1 +1,5 @@
-import './Toggle';
+import { define } from 'skatejs';
+import { Toggle } from './Toggle';
+
+export { Toggle } from './Toggle';
+define( Toggle );


### PR DESCRIPTION
affects: @blaze-elements/toggle

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Toggle does not emit onchange event when value changed


**What is the new behavior?**
OnChange was emitted when toggle checked was changed


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
