### PR TITLE
feat(card): follow actual guidelines && condition for rendering h...

### DIFF
--- a/packages/card/Card.test.tsx
+++ b/packages/card/Card.test.tsx
@@ -1,17 +1,26 @@
-import { Card } from './index';
-
+import * as expect from 'expect';
 import { h, mount } from 'bore';
+import { Card } from './index';
 
 describe( Card.is, () => {
 
-  it( 'should render', () => {
+  describe( `Custom element`, () => {
 
-    console.warn( 'Missing tests for Card!' );
+    it( `should be registered`, () => {
+      expect( customElements.get( Card.is ) ).toBe( Card );
+    } );
 
-    return mount(
-      <Card />
-    ).wait();
+    it( `should render via JSX IntrinsicElement`, () => {
+      return mount( <bl-card>Content</bl-card> ).wait(( element ) => {
+        expect( element.node.localName ).toBe( Card.is );
+      } );
+    } );
 
+    it( `should render`, () => {
+      return mount( <Card>Content</Card> ).wait(( element ) => {
+        expect( element.has( '.c-card' ) ).toBe( true );
+      } );
+    } );
   } );
 
 } );

--- a/packages/card/Card.tsx
+++ b/packages/card/Card.tsx
@@ -2,7 +2,7 @@ import { h, Component } from 'skatejs';
 import styles from './Card.scss';
 import { shadyCssStyles } from '@blaze-elements/common';
 
-export type CardProps = Props;
+export type CardProps = Props & Events;
 export type Props = {};
 export type Events = {};
 

--- a/packages/card/Card.tsx
+++ b/packages/card/Card.tsx
@@ -1,8 +1,7 @@
 import { h, Component } from 'skatejs';
 import styles from './Card.scss';
-import { shadyCssStyles } from '../_helpers';
+import { shadyCssStyles } from '@blaze-elements/common';
 
-export default class Card extends Component<void> {
 export type CardProps = Props;
 export type Props = {};
 export type Events = {};

--- a/packages/card/Card.tsx
+++ b/packages/card/Card.tsx
@@ -1,24 +1,45 @@
 import { h, Component } from 'skatejs';
 import styles from './Card.scss';
+import { shadyCssStyles } from '../_helpers';
 
 export default class Card extends Component<void> {
+export type CardProps = Props;
+export type Props = {};
+export type Events = {};
+
+@shadyCssStyles()
+export default class Card extends Component<CardProps> {
+
+  get css() { return styles; }
 
   renderCallback() {
+
+    const hasHeader = this.querySelectorAll( '[slot="heading"]' ).length > 0;
+    const hasFooter = this.querySelectorAll( '[slot="footer"]' ).length > 0;
+
     return [
       <style>{styles}</style>,
       <div class="c-card">
-        <header class="c-card__header">
-          <slot name="dismiss" />
-          <h2 class="c-heading">
-            <slot name="heading" />
-          </h2>
-        </header>
+
+        {hasHeader &&
+          <header class="c-card__header">
+            <slot name="dismiss" />
+            <h2 class="c-heading">
+              <slot name="heading" />
+            </h2>
+          </header>
+        }
+
         <div class="c-card__body">
           <slot name="body" />
         </div>
-        <footer class="c-card__footer">
-          <slot name="footer" />
-        </footer>
+
+        {hasFooter &&
+          <footer class="c-card__footer">
+            <slot name="footer" />
+          </footer>
+        }
+
       </div>
     ];
   }

--- a/packages/card/CardContent.test.tsx
+++ b/packages/card/CardContent.test.tsx
@@ -1,0 +1,26 @@
+import * as expect from 'expect';
+import { h, mount } from 'bore';
+import { CardContent } from './index';
+
+describe( CardContent.is, () => {
+
+  describe( `Custom element`, () => {
+
+    it( `should be registered`, () => {
+      expect( customElements.get( CardContent.is ) ).toBe( CardContent );
+    } );
+
+    it( `should render via JSX IntrinsicElement`, () => {
+      return mount( <bl-card-content>Content</bl-card-content> ).wait(( element ) => {
+        expect( element.node.localName ).toBe( CardContent.is );
+      } );
+    } );
+
+    it( `should render`, () => {
+      return mount( <CardContent>Content</CardContent> ).wait(( element ) => {
+        expect( element.has( '.c-card__body' ) ).toBe( true );
+      } );
+    } );
+  } );
+
+} );

--- a/packages/card/CardContent.tsx
+++ b/packages/card/CardContent.tsx
@@ -1,6 +1,6 @@
 import { h, Component } from 'skatejs';
 import styles from './Card.scss';
-import { shadyCssStyles } from '../_helpers';
+import { shadyCssStyles } from '@blaze-elements/common';
 
 export type CardContentProps = Props & Events;
 export type Props = {};

--- a/packages/card/CardContent.tsx
+++ b/packages/card/CardContent.tsx
@@ -2,24 +2,19 @@ import { h, Component } from 'skatejs';
 import styles from './Card.scss';
 import { shadyCssStyles } from '../_helpers';
 
-export default class Card extends Component<void> {
-export type CardProps = Props;
+export type CardContentProps = Props & Events;
 export type Props = {};
 export type Events = {};
 
 @shadyCssStyles()
-export default class Card extends Component<CardProps> {
+export default class CardContent extends Component<CardContentProps> {
 
   get css() { return styles; }
 
   renderCallback() {
-
     return [
-      <style>{styles}</style>,
-      <div class="c-card">
-
+      <div class="c-card__body">
         <slot />
-
       </div>
     ];
   }

--- a/packages/card/CardFooter.test.tsx
+++ b/packages/card/CardFooter.test.tsx
@@ -1,0 +1,26 @@
+import * as expect from 'expect';
+import { h, mount } from 'bore';
+import { CardFooter } from './index';
+
+describe( CardFooter.is, () => {
+
+  describe( `Custom element`, () => {
+
+    it( `should be registered`, () => {
+      expect( customElements.get( CardFooter.is ) ).toBe( CardFooter );
+    } );
+
+    it( `should render via JSX IntrinsicElement`, () => {
+      return mount( <bl-card-footer>Footer</bl-card-footer> ).wait(( element ) => {
+        expect( element.node.localName ).toBe( CardFooter.is );
+      } );
+    } );
+
+    it( `should render`, () => {
+      return mount( <CardFooter>Footer</CardFooter> ).wait(( element ) => {
+        expect( element.has( '.c-card__footer' ) ).toBe( true );
+      } );
+    } );
+  } );
+
+} );

--- a/packages/card/CardFooter.tsx
+++ b/packages/card/CardFooter.tsx
@@ -14,7 +14,7 @@ export default class CardFooter extends Component<CardFooterProps> {
   renderCallback() {
     return [
       <footer class="c-card__footer">
-        <slot/>
+        <slot />
       </footer>
     ];
   }

--- a/packages/card/CardFooter.tsx
+++ b/packages/card/CardFooter.tsx
@@ -1,6 +1,6 @@
 import { h, Component } from 'skatejs';
 import styles from './Card.scss';
-import { shadyCssStyles } from '../_helpers';
+import { shadyCssStyles } from '@blaze-elements/common';
 
 export type CardFooterProps = Props & Events;
 export type Props = {};

--- a/packages/card/CardFooter.tsx
+++ b/packages/card/CardFooter.tsx
@@ -2,25 +2,20 @@ import { h, Component } from 'skatejs';
 import styles from './Card.scss';
 import { shadyCssStyles } from '../_helpers';
 
-export default class Card extends Component<void> {
-export type CardProps = Props;
+export type CardFooterProps = Props & Events;
 export type Props = {};
 export type Events = {};
 
 @shadyCssStyles()
-export default class Card extends Component<CardProps> {
+export default class CardFooter extends Component<CardFooterProps> {
 
   get css() { return styles; }
 
   renderCallback() {
-
     return [
-      <style>{styles}</style>,
-      <div class="c-card">
-
-        <slot />
-
-      </div>
+      <footer class="c-card__footer">
+        <slot/>
+      </footer>
     ];
   }
 }

--- a/packages/card/CardHeader.test.tsx
+++ b/packages/card/CardHeader.test.tsx
@@ -1,0 +1,26 @@
+import * as expect from 'expect';
+import { h, mount } from 'bore';
+import { CardHeader } from './index';
+
+describe( CardHeader.is, () => {
+
+  describe( `Custom element`, () => {
+
+    it( `should be registered`, () => {
+      expect( customElements.get( CardHeader.is ) ).toBe( CardHeader );
+    } );
+
+    it( `should render via JSX IntrinsicElement`, () => {
+      return mount( <bl-card-header>Header</bl-card-header> ).wait(( element ) => {
+        expect( element.node.localName ).toBe( CardHeader.is );
+      } );
+    } );
+
+    it( `should render`, () => {
+      return mount( <CardHeader>Header</CardHeader> ).wait(( element ) => {
+        expect( element.has( '.c-card__header' ) ).toBe( true );
+      } );
+    } );
+  } );
+
+} );

--- a/packages/card/CardHeader.tsx
+++ b/packages/card/CardHeader.tsx
@@ -2,25 +2,23 @@ import { h, Component } from 'skatejs';
 import styles from './Card.scss';
 import { shadyCssStyles } from '../_helpers';
 
-export default class Card extends Component<void> {
-export type CardProps = Props;
+export type CardHeaderProps = Props & Events;
 export type Props = {};
 export type Events = {};
 
 @shadyCssStyles()
-export default class Card extends Component<CardProps> {
+export default class CardHeader extends Component<CardHeaderProps> {
 
   get css() { return styles; }
 
   renderCallback() {
-
     return [
-      <style>{styles}</style>,
-      <div class="c-card">
-
-        <slot />
-
-      </div>
+      <header class="c-card__header">
+        <slot name="dismiss" />
+        <h2 class="c-heading">
+          <slot/>
+        </h2>
+      </header>
     ];
   }
 }

--- a/packages/card/CardHeader.tsx
+++ b/packages/card/CardHeader.tsx
@@ -16,7 +16,7 @@ export default class CardHeader extends Component<CardHeaderProps> {
       <header class="c-card__header">
         <slot name="dismiss" />
         <h2 class="c-heading">
-          <slot/>
+          <slot />
         </h2>
       </header>
     ];

--- a/packages/card/CardHeader.tsx
+++ b/packages/card/CardHeader.tsx
@@ -1,6 +1,6 @@
 import { h, Component } from 'skatejs';
 import styles from './Card.scss';
-import { shadyCssStyles } from '../_helpers';
+import { shadyCssStyles } from '@blaze-elements/common';
 
 export type CardHeaderProps = Props & Events;
 export type Props = {};

--- a/packages/card/CardItem.test.tsx
+++ b/packages/card/CardItem.test.tsx
@@ -1,0 +1,51 @@
+import * as expect from 'expect';
+import { h, mount, WrappedNode } from 'bore';
+import { CardItem } from './index';
+
+describe( CardItem.is, () => {
+
+  describe( `Custom element`, () => {
+
+    it( `should be registered`, () => {
+      expect( customElements.get( CardItem.is ) ).toBe( CardItem );
+    } );
+
+    it( `should render via JSX IntrinsicElement`, () => {
+      return mount( <bl-card-item>Item</bl-card-item> ).wait(( element ) => {
+        expect( element.node.localName ).toBe( CardItem.is );
+      } );
+    } );
+
+    it( `should render`, () => {
+      return mount( <CardItem>Item</CardItem> ).wait(( element ) => {
+        expect( element.has( '.c-card__item' ) ).toBe( true );
+      } );
+    } );
+
+  } );
+
+  describe( `API`, () => {
+
+    describe( `[selected]`, () => {
+
+      it( `should set selected flag`, () => {
+        return mount(
+          <bl-card-item selected>Item</bl-card-item>
+        ).wait( checkSelected );
+      } );
+
+      it( `should set selected flag via attribute`, () => {
+        return mount(
+          <bl-card-item attrs={{ selected: true }}>Item</bl-card-item>
+        ).wait( checkSelected );
+      } );
+
+      function checkSelected( element: WrappedNode ) {
+        expect( element.has( '.c-card__item--active' ) ).toBe( true );
+      }
+
+    } );
+
+  } );
+
+} );

--- a/packages/card/CardItem.tsx
+++ b/packages/card/CardItem.tsx
@@ -13,7 +13,7 @@ export default class CardItem extends Component<CardItemProps> {
 
   get css() { return styles; }
 
-  @prop( { type: Boolean } ) selected: boolean;
+  @prop( { type: Boolean, attribute: { source: true } } ) selected: boolean;
 
   renderCallback() {
     const { selected } = this;

--- a/packages/card/CardItem.tsx
+++ b/packages/card/CardItem.tsx
@@ -1,15 +1,17 @@
 import { h, Component } from 'skatejs';
 import styles from './Card.scss';
-import { prop, css } from '@blaze-elements/common';
+import { prop, css, shadyCssStyles } from '@blaze-elements/common';
 
 export type CardItemProps = Props;
-
 export type Props = {
   selected?: boolean,
 };
+export type Events = {};
 
-
+@shadyCssStyles()
 export default class CardItem extends Component<CardItemProps> {
+
+  get css() { return styles; }
 
   @prop( { type: Boolean } ) selected: boolean;
 

--- a/packages/card/index.demo.tsx
+++ b/packages/card/index.demo.tsx
@@ -1,7 +1,7 @@
 import { h, Component } from 'skatejs';
 import { customElement } from '@blaze-elements/common';
 
-import { Card, CardItem } from './index';
+import { Card, CardContent, CardItem, CardHeader, CardFooter } from './index';
 
 @customElement( 'bl-card-demo' )
 export class Demo extends Component<void> {
@@ -15,17 +15,17 @@ export class Demo extends Component<void> {
 
         <div>
           <Card>
-            <span slot="heading">Hello</span>
-            <span slot="body">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quidem, reiciendis.</span>
-            <span slot="footer">Footer baby</span>
+            <CardHeader>Hello</CardHeader>
+            <CardContent>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quidem, reiciendis.</CardContent>
+            <CardFooter>Footer baby</CardFooter>
           </Card>
 
           <Card>
-            <span slot="body">
+            <CardContent>
               <CardItem>Item 1</CardItem>
               <CardItem selected>Item 2</CardItem>
               <CardItem>Item 3</CardItem>
-            </span>
+            </CardContent>
           </Card>
         </div>
 

--- a/packages/card/index.test.ts
+++ b/packages/card/index.test.ts
@@ -1,1 +1,5 @@
 import './Card.test';
+import './CardContent.test';
+import './CardFooter.test';
+import './CardHeader.test';
+import './CardItem.test';

--- a/packages/card/index.ts
+++ b/packages/card/index.ts
@@ -1,9 +1,29 @@
-import { GenericTypes, customElement } from '@blaze-elements/common';
-import RawCard, { CardProps, Props, Events } from './Card';
-import RawCardContent, { CardContentProps, Props as PropsCardContent, Events as EventsCardContent } from './CardContent';
-import RawCardItem, { CardItemProps, Props as PropsCardItem, Events as EventsCardItem } from './CardItem';
-import RawCardHeader, { CardHeaderProps, Props as PropsCardHeader, Events as EventsCardHeader } from './CardHeader';
-import RawCardFooter, { CardFooterProps, Props as PropsCardFooter, Events as EventsCardFooter } from './CardFooter';
+import { customElement, GenericTypes } from '../_helpers';
+import RawCard, {
+  CardProps,
+  Props,
+  Events
+} from './Card';
+import RawCardContent, {
+  CardContentProps,
+  Props as PropsCardContent,
+  Events as EventsCardContent
+} from './CardContent';
+import RawCardItem, {
+  CardItemProps,
+  Props as PropsCardItem,
+  Events as EventsCardItem
+} from './CardItem';
+import RawCardHeader, {
+  CardHeaderProps,
+  Props as PropsCardHeader,
+  Events as EventsCardHeader
+} from './CardHeader';
+import RawCardFooter, {
+  CardFooterProps,
+  Props as PropsCardFooter,
+  Events as EventsCardFooter
+} from './CardFooter';
 
 const Card = customElement( 'bl-card' )( RawCard ) as typeof RawCard;
 const CardContent = customElement( 'bl-card-content' )( RawCardContent ) as typeof RawCardContent;

--- a/packages/card/index.ts
+++ b/packages/card/index.ts
@@ -1,22 +1,19 @@
 import { GenericTypes, customElement } from '@blaze-elements/common';
-import { CardItemProps } from './CardItem';
-
-import RawCard from './Card';
-import RawCardItem from './CardItem';
+import RawCard, { CardProps, Props, Events } from './Card';
+import RawCardItem, { CardItemProps, Props as PropsCardItem, Events as EventsCardItem } from './CardItem';
 
 const Card = customElement( 'bl-card' )( RawCard ) as typeof RawCard;
 const CardItem = customElement( 'bl-card-item' )( RawCardItem ) as typeof RawCardItem;
 
-export {
-  Card,
-  CardItem
-};
+export { Card, CardItem };
 
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'bl-card': GenericTypes.IntrinsicCustomElement<void>;
-      'bl-card-item': GenericTypes.IntrinsicCustomElement<CardItemProps>;
+      'bl-card': GenericTypes.IntrinsicCustomElement<CardProps>
+      & GenericTypes.IntrinsicBoreElement<Props, Events>
+      'bl-card-item': GenericTypes.IntrinsicCustomElement<CardItemProps>
+      & GenericTypes.IntrinsicBoreElement<PropsCardItem, EventsCardItem>
     }
   }
 }

--- a/packages/card/index.ts
+++ b/packages/card/index.ts
@@ -1,4 +1,4 @@
-import { customElement, GenericTypes } from '../_helpers';
+import { customElement, GenericTypes } from '@blaze-elements/common';
 import RawCard, {
   CardProps,
   Props,

--- a/packages/card/index.ts
+++ b/packages/card/index.ts
@@ -1,19 +1,31 @@
 import { GenericTypes, customElement } from '@blaze-elements/common';
 import RawCard, { CardProps, Props, Events } from './Card';
+import RawCardContent, { CardContentProps, Props as PropsCardContent, Events as EventsCardContent } from './CardContent';
 import RawCardItem, { CardItemProps, Props as PropsCardItem, Events as EventsCardItem } from './CardItem';
+import RawCardHeader, { CardHeaderProps, Props as PropsCardHeader, Events as EventsCardHeader } from './CardHeader';
+import RawCardFooter, { CardFooterProps, Props as PropsCardFooter, Events as EventsCardFooter } from './CardFooter';
 
 const Card = customElement( 'bl-card' )( RawCard ) as typeof RawCard;
+const CardContent = customElement( 'bl-card-content' )( RawCardContent ) as typeof RawCardContent;
 const CardItem = customElement( 'bl-card-item' )( RawCardItem ) as typeof RawCardItem;
+const CardHeader = customElement( 'bl-card-header' )( RawCardHeader ) as typeof RawCardHeader;
+const CardFooter = customElement( 'bl-card-footer' )( RawCardFooter ) as typeof RawCardFooter;
 
-export { Card, CardItem };
+export { Card, CardContent, CardItem, CardHeader, CardFooter };
 
 declare global {
   namespace JSX {
     interface IntrinsicElements {
       'bl-card': GenericTypes.IntrinsicCustomElement<CardProps>
-      & GenericTypes.IntrinsicBoreElement<Props, Events>
+      & GenericTypes.IntrinsicBoreElement<Props, Events>,
+      'bl-card-content': GenericTypes.IntrinsicCustomElement<CardContentProps>
+      & GenericTypes.IntrinsicBoreElement<PropsCardContent, EventsCardContent>,
       'bl-card-item': GenericTypes.IntrinsicCustomElement<CardItemProps>
-      & GenericTypes.IntrinsicBoreElement<PropsCardItem, EventsCardItem>
+      & GenericTypes.IntrinsicBoreElement<PropsCardItem, EventsCardItem>,
+      'bl-card-header': GenericTypes.IntrinsicCustomElement<CardHeaderProps>
+      & GenericTypes.IntrinsicBoreElement<PropsCardHeader, EventsCardHeader>,
+      'bl-card-footer': GenericTypes.IntrinsicCustomElement<CardFooterProps>
+      & GenericTypes.IntrinsicBoreElement<PropsCardFooter, EventsCardFooter>,
     }
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
We render all (Header & Footer) when is empty
#220 


**What is the new behavior?**
- `<CardHeader>` & `<CardFooter>` & `<CardContent>` added


**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
*old version:*
```
<bl-card>
  <span slot="header">Header</span>
  <span slot="body">Body</span>
  <span slot="footer">Footer</span>
</bl-card>
```
*new version:*
```
<bl-card>
  <bl-card-header>Hello</bl-card-header>
  <bl-card-content>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quidem, reiciendis.</bl-card-content>
  <bl-card-footer>Footer baby</bl-card-footer>
</Card>
```