### PR TITLE
fix(select): remove @bind decorators from 'decko' because IE error

### DIFF
--- a/packages/select/Option.tsx
+++ b/packages/select/Option.tsx
@@ -1,6 +1,5 @@
 import { h, Component } from 'skatejs';
 import { prop, shadyCssStyles, GenericEvents } from '../_helpers';
-import { bind } from 'decko';
 import { SelectCardItem } from './components/CardItem';
 import styles from './Select.scss';
 
@@ -24,6 +23,11 @@ export default class Option extends Component<OptionProps> {
   @prop( { type: Boolean } ) private _selected = false;
 
   private slotElement: HTMLSlotElement;
+
+  constructor() {
+    super();
+    this.setSlot = this.setSlot.bind( this );
+  }
 
   get selected() { return this._selected; };
 
@@ -54,7 +58,6 @@ export default class Option extends Component<OptionProps> {
     );
   }
 
-  @bind
   private setSlot( element: HTMLSlotElement ) {
     this.slotElement = element;
   }

--- a/packages/select/Select.tsx
+++ b/packages/select/Select.tsx
@@ -1,5 +1,4 @@
 import { h, Component, props } from 'skatejs';
-import { bind } from 'decko';
 import { GenericEvents, prop, shadyCssStyles } from '../_helpers';
 import styles from './Select.scss';
 import Option from './Option';
@@ -51,6 +50,13 @@ export default class Select extends Component<SelectProps> {
   private _selected: Option;
   private options: Option[];
 
+  constructor() {
+    super();
+    this.setSlot = this.setSlot.bind( this );
+    this.toggleOptions = this.toggleOptions.bind( this );
+    this.closeOptions = this.closeOptions.bind( this );
+  }
+
   connectedCallback() {
     super.connectedCallback();
     setTimeout(() => {
@@ -90,19 +96,16 @@ export default class Select extends Component<SelectProps> {
     ] );
   }
 
-  @bind
   setSlot( element: HTMLSlotElement ) {
     this.slotElement = element;
   }
 
-  @bind
   toggleOptions() {
     props( this, {
       open: !this.open
     } );
   }
 
-  @bind
   closeOptions() {
     props( this, {
       open: false

--- a/packages/select/index.demo.tsx
+++ b/packages/select/index.demo.tsx
@@ -2,7 +2,6 @@ import { h, Component, props } from 'skatejs';
 import { customElement } from '../_helpers';
 import { Select, Option } from './index';
 import { prop } from '../_helpers/decorators';
-import { bind } from 'decko';
 import OptionType from './Option';
 
 export type DemoProps = { value?: string, value2?: string };
@@ -13,7 +12,12 @@ export class Demo extends Component<DemoProps> {
   @prop( { type: String } ) value = 'en';
   @prop( { type: String } ) value2: string;
 
-  @bind
+  constructor() {
+    super();
+    this.setSelected = this.setSelected.bind( this );
+    this.setSelected2 = this.setSelected2.bind( this );
+  }
+
   setSelected( e: MouseEvent ) {
     const target = e.target as OptionType;
     props( this, {
@@ -21,7 +25,6 @@ export class Demo extends Component<DemoProps> {
     } );
   }
 
-  @bind
   setSelected2( e: MouseEvent ) {
     const target = e.target as OptionType;
     props( this, {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [ ] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Select does not work in IE.


**What is the new behavior?**
Select works in IE.



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
