### PR TITLE
fix: remove @bind decorators from 'decko' because IE error

### DIFF
--- a/packages/calendar/index.demo.tsx
+++ b/packages/calendar/index.demo.tsx
@@ -1,7 +1,5 @@
 import { h, Component } from 'skatejs';
-import { bind } from 'decko';
 import { GenericEvents, customElement, prop } from '@blaze-elements/common';
-
 import { Calendar } from './index';
 
 @customElement( 'bl-calendar-demo' )
@@ -32,6 +30,11 @@ export class Demo extends Component<void> {
     }
   };
 
+  constructor() {
+    super();
+    this.dateChangeHandler = this.dateChangeHandler.bind( this );
+  }
+
   renderCallback() {
     return (
       <fieldset>
@@ -52,7 +55,6 @@ export class Demo extends Component<void> {
     );
   }
 
-  @bind
   private dateChangeHandler( event: GenericEvents.CustomChangeEvent<Date> ) {
     this.selectedDate = event.detail.value;
   }

--- a/packages/tag/TagSelector.tsx
+++ b/packages/tag/TagSelector.tsx
@@ -1,5 +1,4 @@
 import { h, Component } from 'skatejs';
-import { bind } from 'decko';
 
 import { GenericEvents, EventEmitter, event, prop } from '@blaze-elements/common';
 import { Input } from '@blaze-elements/input';
@@ -31,6 +30,12 @@ export class TagSelector extends Component<TagSelectorProps> {
 
   @event() tagChange = new EventEmitter<{ tags: string[] }>();
 
+  constructor() {
+    super();
+    this.handleInput = this.handleInput.bind( this );
+    this.handleTagClose = this.handleTagClose.bind( this );
+  }
+
   renderCallback() {
 
     const tags = this.tags.map(( label ) => (
@@ -53,7 +58,6 @@ export class TagSelector extends Component<TagSelectorProps> {
     ];
   }
 
-  @bind
   private handleInput( event: GenericEvents.CustomChangeEvent<string> ) {
     const input = event.target as Input;
     const value = event.detail.value;
@@ -75,7 +79,6 @@ export class TagSelector extends Component<TagSelectorProps> {
   }
 
   // @TODO correctly annotate event to proper type
-  @bind
   private handleTagClose( event: CustomEvent ) {
     const target = event.target as Tag;
     const newTags = this.tags.filter(( tag ) => tag !== target.label );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [ ] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
`@bind` is causing issues in IE


**What is the new behavior?**
`@bind` was removed everywhere.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
