### PR TITLE
refactor(alert): follow actual guideline

### DIFF
--- a/packages/alert/Alert.scss
+++ b/packages/alert/Alert.scss
@@ -1,3 +1,2 @@
 @import "../generics.shared";
 @import '~blaze/scss/components.alerts';
-@import '~blaze/scss/components.buttons';

--- a/packages/alert/Alert.test.tsx
+++ b/packages/alert/Alert.test.tsx
@@ -1,16 +1,40 @@
-import { Alert } from './';
-
+import * as expect from 'expect';
 import { h, mount } from 'bore';
+
+import { Alert } from './index';
 
 describe( Alert.is, () => {
 
-  it( 'should render', () => {
+  describe( `Custom element`, () => {
+    it( `should be registered`, () => {
 
-    console.warn( 'Missing tests for Alert!' );
+      expect( customElements.get( Alert.is ) ).toBe( Alert );
 
-    return mount(
-      <Alert />
-    ).wait();
+    } );
+
+    it( `should render via JSX IntrinsicElement`, () => {
+
+      return mount(
+        <bl-alert />
+      ).wait(( element ) => {
+
+        expect( element.node.localName ).toBe( Alert.is );
+
+      } );
+
+    } );
+
+    it( `should render via JSX class`, () => {
+
+      return mount(
+        <Alert isOpen={true} />
+      ).wait(( element ) => {
+
+        expect( element.node.localName ).toBe( Alert.is );
+
+      } );
+
+    } );
 
   } );
 

--- a/packages/alert/Alert.tsx
+++ b/packages/alert/Alert.tsx
@@ -1,50 +1,30 @@
-import { h, Component, prop, emit } from 'skatejs';
-
-import { ColorType, cssClassForColorType, css } from '@blaze-elements/common';
-
-// @FIXME this needs to be imported from package import {Button} from '@blaze-elements/button'
-import { Button } from '../button';
-
+import { h, Component, emit } from 'skatejs';
+import { ColorType, cssClassForColorType, css, prop, shadyCssStyles } from '@blaze-elements/common';
 import styles from './Alert.scss';
+import AlertButton from './components/Button';
 
-type AlertProps = Props & EventProps;
-type Props = {
+export type AlertProps = Props & Events;
+export type Props = {
   color?: ColorType,
   isOpen?: boolean,
 };
-type EventProps = {
+export type Events = {
   onAlertClose?: ( ev: CustomEvent ) => void,
 };
 
-// extend JSX.IntrinsicElements namepsace with our definition
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      'bl-alert': AlertProps & Partial<HTMLElement>,
-    }
-  }
-}
+@shadyCssStyles()
+export default class Alert extends Component<AlertProps> {
 
-export class Alert extends Component<AlertProps> {
-  static get is() { return 'bl-alert'; }
-  static get props() {
-    return {
-      color: prop.string( {
-        attribute: true
-      } ),
-      isOpen: prop.boolean( {
-        attribute: true
-      } )
-    };
-  }
+  @prop( { type: String, attribute: { source: true } } ) color: ColorType;
+  @prop( { type: Boolean, attribute: { source: true } } ) isOpen = false;
+
   static get events() {
     return {
       alertClose: 'alertClose'
     };
   }
 
-  isOpen?= false;
-  color?: ColorType;
+  get css() { return styles; }
 
   renderCallback() {
     const { color, isOpen } = this;
@@ -52,10 +32,9 @@ export class Alert extends Component<AlertProps> {
     const className = css( 'c-alert', colorClass );
 
     return [
-      <style>{styles}</style>,
       isOpen && (
         <div className={className}>
-          <Button close onClick={this.handleClose}>×</Button>
+          <AlertButton close onClick={this.handleClose}>×</AlertButton>
           <slot />
         </div>
       )

--- a/packages/alert/components/Button.tsx
+++ b/packages/alert/components/Button.tsx
@@ -1,0 +1,5 @@
+import { customElement } from '@blaze-elements/common';
+import Button from '@blaze-elements/button/Button';
+
+@customElement('bl-alert-button')
+export default class AlertButton extends Button {}

--- a/packages/alert/index.demo.tsx
+++ b/packages/alert/index.demo.tsx
@@ -1,18 +1,15 @@
-import { h, Component, prop, props, define } from 'skatejs';
-import { Alert } from './index';
+import { h, Component, props } from 'skatejs';
+import { customElement, prop } from '@blaze-elements/common';
 
-import { Button } from '../button';
+import { Alert } from './index';
+import AlertButton from './components/Button';
 
 type DemoProps = { isOpen?: boolean };
-export class Demo extends Component<DemoProps> {
-  static get is() { return 'bl-alert-demo'; }
-  static get props() {
-    return {
-      isOpen: prop.boolean()
-    };
-  }
 
-  isOpen = false;
+@customElement( 'bl-alert-demo' )
+export class Demo extends Component<DemoProps> {
+
+  @prop( { type: Boolean } ) isOpen = false;
 
   renderCallback() {
     const { isOpen } = this;
@@ -22,7 +19,7 @@ export class Demo extends Component<DemoProps> {
       <fieldset>
         <legend>{Alert.is}</legend>
 
-        {!isOpen && <Button onClick={this.handleAlertOpen}>Show alerts</Button>}
+        {!isOpen && <AlertButton onClick={this.handleAlertOpen}>Show alerts</AlertButton>}
 
         <div>
           <bl-alert isOpen={this.isOpen} onAlertClose={this.handleAlertClose}>Alert default via dom element</bl-alert>
@@ -41,10 +38,9 @@ export class Demo extends Component<DemoProps> {
   private handleAlertOpen = () => {
     props( this, { isOpen: true } );
   }
+
   private handleAlertClose = () => {
     props( this, { isOpen: false } );
   }
 
 }
-
-define( Demo );

--- a/packages/alert/index.ts
+++ b/packages/alert/index.ts
@@ -1,9 +1,18 @@
-import { define } from 'skatejs';
+import { customElement, GenericTypes } from '@blaze-elements/common';
+import RawAlert, {
+  AlertProps,
+  Props,
+  Events
+} from './Alert';
+const Alert = customElement( 'bl-alert' )( RawAlert ) as typeof RawAlert;
+export { Alert };
 
-import { Alert } from './Alert';
-
-// export for public access to Skate Class
-export { Alert } from './Alert';
-
-// register WebComponent by our name
-define( Alert );
+// extend JSX.IntrinsicElements namepsace with our definition
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'bl-alert': GenericTypes.IntrinsicCustomElement<AlertProps>
+      & GenericTypes.IntrinsicBoreElement<Props, Events>,
+    }
+  }
+}

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -21,6 +21,7 @@
     "build:test:watch": "../../node_modules/.bin/webpack-dev-server --config ../../webpack.config.js --env.test --env.element=alert"
   },
   "dependencies": {
-    "@blaze-elements/common": "^1.0.0"
+    "@blaze-elements/button": "1.0.1",
+    "@blaze-elements/common": "1.0.1"
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Alert is not refactored


**What is the new behavior?**
Add decorators, define component, importing, exporting are now in index


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

affects: @blaze-elements/alert

Closes #243