### PR TITLE
refactor(badge): follow actual guideline

### DIFF
--- a/packages/badge/Badge.test.tsx
+++ b/packages/badge/Badge.test.tsx
@@ -6,6 +6,7 @@ import { Badge } from './index';
 describe( Badge.is, () => {
 
   describe( `Custom element`, () => {
+
     it( `should be registered`, () => {
 
       expect( customElements.get( Badge.is ) ).toBe( Badge );

--- a/packages/badge/Badge.tsx
+++ b/packages/badge/Badge.tsx
@@ -1,48 +1,23 @@
 import styles from './Badge.scss';
-import { h, Component, prop } from 'skatejs';
-import { ColorType, cssClassForColorType, css } from '@blaze-elements/common';
+import { h, Component } from 'skatejs';
+import { ColorType, cssClassForColorType, css, prop, shadyCssStyles } from '@blaze-elements/common';
 
-type BadgeProps = Props;
-type Props = {
+export type BadgeProps = Props & Events;
+export type Props = {
   color?: ColorType,
   rounded?: boolean,
   ghost?: boolean,
 };
+export type Events = {};
 
-// extend JSX.IntrinsicElements namespace with our definition
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      'bl-badge': BadgeProps & Partial<HTMLElement>
-    }
-  }
-}
+@shadyCssStyles()
+export default class Badge extends Component<BadgeProps> {
 
-export class Badge extends Component<BadgeProps> {
-  static get is() { return 'bl-badge'; }
-  static get props() {
-    return {
-      color: prop.string( {
-        attribute: {
-          source: true
-        }
-      } ),
-      rounded: prop.boolean( {
-        attribute: {
-          source: true
-        }
-      } ),
-      ghost: prop.boolean( {
-        attribute: {
-          source: true
-        }
-      } ),
-    };
-  }
+  @prop( { type: String, attribute: { source: true } } ) color: ColorType;
+  @prop( { type: Boolean, attribute: { source: true } } ) rounded: boolean;
+  @prop( { type: Boolean, attribute: { source: true } } ) ghost: boolean;
 
-  color: ColorType;
-  rounded: boolean;
-  ghost: boolean;
+  get css() { return styles; }
 
   renderCallback() {
 
@@ -60,7 +35,6 @@ export class Badge extends Component<BadgeProps> {
     );
 
     return [
-      <style>{styles}</style>,
       <span className={className}><slot /></span>
     ];
   }

--- a/packages/badge/index.demo.tsx
+++ b/packages/badge/index.demo.tsx
@@ -1,5 +1,5 @@
 import { h, Component } from 'skatejs';
-import { Badge } from './Badge';
+import { Badge } from './index';
 
 export class Demo extends Component<void> {
   static get is() { return 'bl-badge-demo'; }

--- a/packages/badge/index.ts
+++ b/packages/badge/index.ts
@@ -1,5 +1,15 @@
-import { define } from 'skatejs';
-import { Badge } from './Badge';
+import { customElement, GenericTypes } from '@blaze-elements/common';
 
-export { Badge } from './Badge';
-define( Badge );
+import RawBadge, { BadgeProps, Props, Events } from './Badge';
+const Badge = customElement( 'bl-badge' )( RawBadge ) as typeof RawBadge;
+
+export { Badge };
+
+// extend JSX.IntrinsicElements namespace with our definition
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'bl-badge': GenericTypes.IntrinsicCustomElement<BadgeProps> & GenericTypes.IntrinsicBoreElement<Props, Events>
+    }
+  }
+}

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -21,6 +21,6 @@
     "build:test:watch": "../../node_modules/.bin/webpack-dev-server --config ../../webpack.config.js --env.test --env.element=badge"
   },
   "dependencies": {
-    "@blaze-elements/common": "^1.0.0"
+    "@blaze-elements/common": "1.0.1"
   }
 }


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Badge needs to be refactored to following actual guideline


**What is the new behavior?**
Decorators added, define component is in index



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

affects: @blaze-elements/badge

Closes #253
