### PR TITLE
refactor(accordion): align with current style guides

### DIFF
--- a/packages/accordion/Accordion.test.tsx
+++ b/packages/accordion/Accordion.test.tsx
@@ -1,16 +1,40 @@
-import { Accordion } from './Accordion';
-
-import { h, mount } from 'bore';
+import { mount, h } from 'bore';
+import * as expect from 'expect';
+import { Accordion } from './index';
 
 describe( Accordion.is, () => {
 
-  it( 'should render', () => {
+  describe( `Custom element`, () => {
 
-    console.warn( 'Missing tests for Accordion!' );
+    it( `should be registered`, () => {
 
-    return mount(
-      <Accordion />
-    ).wait();
+      expect( customElements.get( Accordion.is ) ).toBe( Accordion );
+
+    } );
+
+    it( `should render via JSX IntrinsicElement`, () => {
+
+      return mount(
+        <bl-accordion />
+      ).wait(( element ) => {
+
+        expect( element.node.localName ).toBe( Accordion.is );
+
+      } );
+
+    } );
+
+    it( `should render via JSX class`, () => {
+
+      return mount(
+        <bl-accordion />
+      ).wait(( element ) => {
+
+        expect( element.has( '.c-card--accordion' ) ).toBe( true );
+
+      } );
+
+    } );
 
   } );
 

--- a/packages/accordion/Accordion.tsx
+++ b/packages/accordion/Accordion.tsx
@@ -1,10 +1,22 @@
 import { h, Component } from 'skatejs';
 import styles from './Accordion.scss';
-import { Collapsible, StateChangedEvent } from '../collapsible/Collapsible';
+import { shadyCssStyles } from '@blaze-elements/common';
+import Collapsible, { StateChangedEvent } from '@blaze-elements/collapsible/Collapsible';
 
+export type AccordionProps = Props & EventProps;
 
-export class Accordion extends Component<void> {
-  static get is() { return 'bl-accordion'; }
+export type Attrs = {};
+
+export type Props = {};
+
+export type EventProps = {};
+
+export type Events = {};
+
+@shadyCssStyles()
+export default class Accordion extends Component<AccordionProps> {
+
+  get css() { return styles; }
 
   private items = new Array<Collapsible>();
 
@@ -28,12 +40,11 @@ export class Accordion extends Component<void> {
       }
     }
 
-    return [
-      <style>{styles}</style>,
+    return (
       <div className="c-card c-card--accordion">
         <slot />
       </div>
-    ];
+    );
   }
 
   private handleStateChanged( event: StateChangedEvent ) {
@@ -44,5 +55,3 @@ export class Accordion extends Component<void> {
     } );
   }
 }
-
-customElements.define( Accordion.is, Accordion );

--- a/packages/accordion/index.demo.tsx
+++ b/packages/accordion/index.demo.tsx
@@ -1,13 +1,14 @@
 import { h, Component } from 'skatejs';
-import { Accordion } from './Accordion';
-import { Collapsible } from '../collapsible/Collapsible';
+import { customElement } from '@blaze-elements/common';
 
+import { Accordion } from './index';
+import { Collapsible } from '@blaze-elements/collapsible';
+
+@customElement( 'bl-accordion-demo' )
 export class Demo extends Component<void> {
-  static get is() { return 'bl-accordion-demo'; }
 
   renderCallback() {
-    return [
-      <style />,
+    return (
       <fieldset>
         <legend>{Accordion.is}</legend>
 
@@ -32,9 +33,6 @@ export class Demo extends Component<void> {
           </Collapsible>
         </Accordion>
       </fieldset>
-    ];
+    );
   }
 }
-
-customElements.define( Demo.is, Demo );
-

--- a/packages/accordion/index.ts
+++ b/packages/accordion/index.ts
@@ -1,1 +1,19 @@
-import './Accordion';
+
+import { customElement, GenericTypes } from '@blaze-elements/common';
+import RawAccordion, { AccordionProps, Attrs, Events } from './Accordion';
+
+const Accordion = customElement( 'bl-accordion' )( RawAccordion ) as typeof RawAccordion;
+
+export {
+  Accordion
+};
+
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'bl-accordion': GenericTypes.IntrinsicCustomElement<AccordionProps>
+      & GenericTypes.IntrinsicBoreElement<Attrs, Events>
+    }
+  }
+}

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -19,5 +19,9 @@
     "build": "../../node_modules/.bin/rimraf dist && ../../node_modules/.bin/webpack --config ../../webpack.config.js --env.prod --env.element=accordion",
     "build:test": "../../node_modules/.bin/rimraf dist && ../../node_modules/.bin/webpack --config ../../webpack.config.js --env.test --env.element=accordion",
     "build:test:watch": "../../node_modules/.bin/webpack-dev-server --config ../../webpack.config.js --env.test --env.element=accordion"
+  },
+  "dependencies": {
+    "@blaze-elements/collapsible": "^1.0.0",
+    "@blaze-elements/common": "^1.0.0"
   }
 }


### PR DESCRIPTION
Closes #254 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
#261 has to be closed prior merging this