### PR TITLE
refactor(input): follow actual guideline

### DIFF
--- a/packages/input/Input.tsx
+++ b/packages/input/Input.tsx
@@ -1,15 +1,16 @@
-import { h, Component, prop, emit } from 'skatejs';
+import { h, Component, emit } from 'skatejs';
 import styles from './Input.scss';
 import {
   Size,
   cssClassForSize,
   css,
-  GenericTypes,
-  GenericEvents
+  GenericEvents,
+  prop,
+  shadyCssStyles
 } from '@blaze-elements/common';
 
 
-type TypesType = {
+export type TypesType = {
   text: string,
   password: string,
   reset: string,
@@ -17,86 +18,47 @@ type TypesType = {
   number: string
 };
 
-type InputProps = Props & EventProps;
-type EventProps = {
+export type InputProps = Props & EventProps;
+export type EventProps = {
   onKeyup?: GenericEvents.KeyupHandler,
   onFocus?: GenericEvents.FocusHandler,
   onBlur?: GenericEvents.BlurHandler,
   onChange?: GenericEvents.CustomChangeHandler<string>,
 };
-type Events = {
+export type Events = {
   keyup?: GenericEvents.KeyupHandler,
   focus?: GenericEvents.FocusHandler,
   blur?: GenericEvents.BlurHandler,
   change?: GenericEvents.CustomChangeHandler<string>,
 };
-type Props = {
+export type Props = {
   value: string,
   valid?: string,
   placeholder?: string,
-  disabled?: boolean,
+  disabled?: boolean | null,
   inputSize?: keyof Size,
   type?: keyof TypesType
 };
 
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      'bl-input': GenericTypes.IntrinsicCustomElement<InputProps> & GenericTypes.IntrinsicBoreElement<Props, Events>
-    }
-  }
-}
+@shadyCssStyles()
+export default class Input extends Component<InputProps> {
 
-export class Input extends Component<InputProps> {
-  static get is() { return 'bl-input'; }
+  get css() { return styles; }
 
-  static get props() {
-    return {
-      value: prop.string( {
-        attribute: {
-          source: true
-        }
-      } ),
-      valid: prop.string( {
-        attribute: {
-          source: true
-        }
-      } ),
-      placeholder: prop.string( {
-        attribute: {
-          source: true
-        }
-      } ),
-      disabled: prop.boolean( {
-        attribute: {
-          source: true
-        }
-      } ),
-      type: prop.string( {
-        attribute: {
-          source: true
-        }
-      } ),
-      inputSize: prop.string( {
-        attribute: {
-          source: true
-        }
-      } ),
-    };
-  }
+  @prop( { type: String, attribute: { source: true } } ) value: string;
+  @prop( { type: String, attribute: { source: true } } ) placeholder: string;
+  @prop( { type: String, attribute: { source: true } } ) type = 'text';
+  @prop( { type: String, attribute: { source: true } } ) inputSize: Size;
+  @prop( { type: String, attribute: { source: true } } ) valid: string;
+  // @prop( { type: Boolean, attribute: { source: true } } ) disabled: boolean;
+
+  disabled: boolean | null = null;
 
   static get events() {
     return {
       change: 'change',
     };
   }
-
-  valid: string;
-  value: string;
-  inputSize: Size;
-  placeholder: string;
-  type = 'text';
-  disabled: boolean;
 
   constructor() {
     super();
@@ -116,7 +78,6 @@ export class Input extends Component<InputProps> {
     );
 
     return [
-      <style>{styles}</style>,
       <input
         className={className}
         type={type}

--- a/packages/input/index.demo.tsx
+++ b/packages/input/index.demo.tsx
@@ -1,16 +1,11 @@
-import { h, Component, prop } from 'skatejs';
+import { h, Component } from 'skatejs';
 import { Input } from './index';
+import { customElement, prop } from '@blaze-elements/common';
 
+@customElement( 'bl-input-demo' )
 export class Demo extends Component<void> {
-  static get is() { return 'bl-input-demo'; }
 
-  static get props() {
-    return {
-      errorValue: prop.string()
-    };
-  }
-
-  errorValue = 'error state';
+  @prop( { type: String } ) errorValue = 'error state';
 
   constructor() {
     super();
@@ -72,5 +67,3 @@ export class Demo extends Component<void> {
     console.log( message );
   }
 }
-
-customElements.define( Demo.is, Demo );

--- a/packages/input/index.ts
+++ b/packages/input/index.ts
@@ -1,5 +1,16 @@
-import { define } from 'skatejs';
-import { Input } from './Input';
+import { customElement, GenericTypes } from '@blaze-elements/common';
+import RawInput, {
+  InputProps,
+  Props,
+  Events
+} from './Input';
+const Input = customElement( 'bl-input' )( RawInput ) as typeof RawInput;
+export { Input };
 
-export { Input } from './Input';
-define( Input );
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'bl-input': GenericTypes.IntrinsicCustomElement<InputProps> & GenericTypes.IntrinsicBoreElement<Props, Events>
+    }
+  }
+}

--- a/packages/tag/TagSelector.tsx
+++ b/packages/tag/TagSelector.tsx
@@ -1,7 +1,7 @@
 import { h, Component } from 'skatejs';
 
 import { GenericEvents, EventEmitter, event, prop } from '@blaze-elements/common';
-import { Input } from '@blaze-elements/input';
+import Input from '@blaze-elements/input/Input';
 
 import styles from './Tag.scss';
 import { Tag } from './Tag';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Input is not refactored.


**What is the new behavior?**
Input will be refactored


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

affects: @blaze-elements/input
Decorators added, define component is in index
Closes #265

Also set correct import path to tag.