### PR TITLE
refactor(tooltip): align with current style guides

### DIFF
--- a/packages/tooltip/Tooltip.tsx
+++ b/packages/tooltip/Tooltip.tsx
@@ -1,48 +1,49 @@
-import { h, Component, prop } from 'skatejs';
+import { h, Component } from 'skatejs';
 import styles from './Tooltip.scss';
-import { css } from '@blaze-elements/common';
+import { css, prop, shadyCssStyles } from '@blaze-elements/common';
 
-const TooltipTypes = {
+export const TooltipTypes = {
   top: 'top',
   left: 'left',
   right: 'right',
   bottom: 'bottom',
 };
 
-// public
-type TooltipProps = {
+export type TooltipProps = Props & EventProps;
+
+export type Attrs = {
   type?: keyof typeof TooltipTypes,
-  label: string,
+  label?: string,
 };
 
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      'bl-tooltip': TooltipProps & Partial<HTMLElement>,
+export type Props = {
+  type?: keyof typeof TooltipTypes,
+  label?: string,
+};
+
+export type EventProps = {};
+
+export type Events = {};
+
+@shadyCssStyles()
+export default class Tooltip extends Component<TooltipProps> {
+
+  @prop( {
+    type: String,
+    attribute: {
+      source: true
+    },
+    default: 'right'
+  } ) type: keyof typeof TooltipTypes;
+
+  @prop( {
+    type: String,
+    attribute: {
+      source: true
     }
-  }
-};
+  } ) label: string;
 
-export class Tooltip extends Component<TooltipProps> {
-  static get is() { return 'bl-tooltip'; }
-  static get props() {
-    return {
-      type: prop.string( {
-        attribute: {
-          source: true
-        },
-        default: 'right'
-      } ),
-      label: prop.string( {
-        attribute: {
-          source: true
-        }
-      } )
-    };
-  }
-
-  type: string;
-  label: string;
+  get css() { return styles; }
 
   renderCallback() {
     const { label, type } = this;
@@ -55,15 +56,14 @@ export class Tooltip extends Component<TooltipProps> {
       }
     );
 
-    return [
-      <style>{styles}</style>,
+    return (
       <span
         className={className}
         aria-label={label}
       >
         <slot />
       </span>
-    ];
+    );
   }
 
 }

--- a/packages/tooltip/index.demo.tsx
+++ b/packages/tooltip/index.demo.tsx
@@ -1,12 +1,12 @@
 import { h, Component } from 'skatejs';
 import { Tooltip } from './index';
+import { customElement } from '@blaze-elements/common';
 
+@customElement( 'bl-tooltip-demo' )
 export class Demo extends Component<void> {
-  static get is() { return 'bl-tooltip-demo'; }
 
   renderCallback() {
-    return [
-      <style />,
+    return (
       <fieldset>
         <legend>{Tooltip.is}</legend>
 
@@ -18,8 +18,6 @@ export class Demo extends Component<void> {
         </div>
 
       </fieldset>
-    ];
+    );
   }
 }
-
-customElements.define( Demo.is, Demo );

--- a/packages/tooltip/index.ts
+++ b/packages/tooltip/index.ts
@@ -1,9 +1,19 @@
-import { define } from 'skatejs';
 
-import { Tooltip } from './Tooltip';
+import { customElement, GenericTypes } from '@blaze-elements/common';
+import RawTooltip, { TooltipProps, Attrs, Events } from './Tooltip';
 
-// export for public access to Skate Class
-export { Tooltip } from './Tooltip';
+const Tooltip = customElement( 'bl-tooltip' )( RawTooltip ) as typeof RawTooltip;
 
-// register WebComponent by our name
-define( Tooltip );
+export {
+  Tooltip
+};
+
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'bl-tooltip': GenericTypes.IntrinsicCustomElement<TooltipProps>
+      & GenericTypes.IntrinsicBoreElement<Attrs, Events>
+    }
+  }
+}


### PR DESCRIPTION
affects: @blaze-elements/tooltip

Closes #276

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
