### PR TITLE
refactor(tree): align with current style guides

### DIFF
--- a/packages/tree/Tree.tsx
+++ b/packages/tree/Tree.tsx
@@ -1,19 +1,28 @@
 import styles from './Tree.scss';
 import { h, Component } from 'skatejs';
+import { shadyCssStyles } from '@blaze-elements/common';
 
-interface TreeProps { }
+export type TreeProps = Props & EventProps;
 
-export class Tree extends Component<TreeProps> {
+export type Attrs = {};
 
-  static get is() { return 'bl-tree'; }
+export type Props = {};
+
+export type EventProps = {};
+
+export type Events = {};
+
+@shadyCssStyles()
+export default class Tree extends Component<TreeProps> {
+
+  get css() { return styles; }
 
   renderCallback() {
 
-    return [
-      <style>{styles}</style>,
+    return (
       <ul className="c-tree"><slot /></ul>
-    ];
-  }
-}
+    );
 
-customElements.define( Tree.is, Tree );
+  }
+
+}

--- a/packages/tree/TreeItem.test.tsx
+++ b/packages/tree/TreeItem.test.tsx
@@ -1,24 +1,24 @@
 import { mount, h } from 'bore';
 import * as expect from 'expect';
-import { Tree } from './index';
+import { TreeItem } from './index';
 
-describe( Tree.is, () => {
+describe( TreeItem.is, () => {
 
   describe( `Custom element`, () => {
 
     it( `should be registered`, () => {
 
-      expect( customElements.get( Tree.is ) ).toBe( Tree );
+      expect( customElements.get( TreeItem.is ) ).toBe( TreeItem );
 
     } );
 
     it( `should render via JSX IntrinsicElement`, () => {
 
       return mount(
-        <bl-tree />
+        <bl-tree-item />
       ).wait(( element ) => {
 
-        expect( element.node.localName ).toBe( Tree.is );
+        expect( element.node.localName ).toBe( TreeItem.is );
 
       } );
 
@@ -27,10 +27,10 @@ describe( Tree.is, () => {
     it( `should render via JSX class`, () => {
 
       return mount(
-        <bl-tree />
+        <bl-tree-item />
       ).wait(( element ) => {
 
-        expect( element.has( '.c-tree' ) ).toBe( true );
+        expect( element.has( '.c-tree__item' ) ).toBe( true );
 
       } );
 

--- a/packages/tree/TreeItem.tsx
+++ b/packages/tree/TreeItem.tsx
@@ -1,23 +1,32 @@
 import styles from './Tree.scss';
-import { h, Component, prop } from 'skatejs';
-import { css } from '@blaze-elements/common';
+import { h, Component, props } from 'skatejs';
+import { css, shadyCssStyles, prop } from '@blaze-elements/common';
 
-interface TreeItemProps {
+export type TreeItemProps = Props & EventProps;
+
+export type Attrs = {
   isOpen?: boolean,
-}
-export class TreeItem extends Component<TreeItemProps> {
+};
 
-  static get is() { return 'bl-tree-item'; }
+export type Props = {
+  isOpen?: boolean,
+};
 
-  static get props() {
-    return {
-      isOpen: prop.boolean( {
-        attribute: true
-      } ),
-    };
-  }
+export type EventProps = {};
 
-  isOpen: boolean;
+export type Events = {};
+
+@shadyCssStyles()
+export default class TreeItem extends Component<TreeItemProps> {
+
+  get css() { return styles; }
+
+  @prop( {
+    type: Boolean,
+    attribute: {
+      source: true
+    }
+  } ) isOpen: boolean;
 
   connectedCallback() {
     super.connectedCallback();
@@ -34,19 +43,16 @@ export class TreeItem extends Component<TreeItemProps> {
         'c-tree__item--expanded': isOpen && hasSubItem,
       }
     );
-    return [
-      <style>{styles}</style>,
+    return (
       <li className={className} onClick={this.handleClick}>
         <slot />
         {isOpen ? <slot name="subItems" /> : null}
       </li>
-    ];
+    );
   }
 
   private handleClick() {
-    this.isOpen = !this.isOpen;
+    props( this, { isOpen: !this.isOpen } );
   }
 
 }
-
-customElements.define( TreeItem.is, TreeItem );

--- a/packages/tree/index.demo.tsx
+++ b/packages/tree/index.demo.tsx
@@ -1,13 +1,12 @@
 import { h, Component } from 'skatejs';
-import { Tree } from './Tree';
-import { TreeItem } from './Tree-item';
+import { Tree, TreeItem } from './index';
+import { customElement } from '@blaze-elements/common';
 
+@customElement( 'bl-tree-demo' )
 export class Demo extends Component<void> {
-  static get is() { return 'bl-tree-demo'; }
 
   renderCallback() {
-    return [
-      <style />,
+    return (
       <fieldset>
         <legend>{Tree.is}</legend>
         <div>
@@ -44,9 +43,6 @@ export class Demo extends Component<void> {
           </Tree>
         </div>
       </fieldset>
-    ];
+    );
   }
 }
-
-
-customElements.define( Demo.is, Demo );

--- a/packages/tree/index.test.ts
+++ b/packages/tree/index.test.ts
@@ -1,1 +1,2 @@
 import './Tree.test';
+import './TreeItem.test';

--- a/packages/tree/index.ts
+++ b/packages/tree/index.ts
@@ -1,2 +1,23 @@
-import './Tree';
-import './Tree-item';
+
+import { customElement, GenericTypes } from '@blaze-elements/common';
+import RawTree, { TreeProps } from './Tree';
+import RawTreeItem, { TreeItemProps } from './TreeItem';
+
+const Tree = customElement( 'bl-tree' )( RawTree ) as typeof RawTree;
+const TreeItem = customElement( 'bl-tree-item' )( RawTreeItem ) as typeof RawTreeItem;
+
+export {
+  Tree,
+  TreeItem,
+};
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'bl-tree': GenericTypes.IntrinsicCustomElement<TreeProps>
+      & GenericTypes.IntrinsicBoreElement<TreeProps, void>;
+      'bl-tree-item': GenericTypes.IntrinsicCustomElement<TreeItemProps>
+      & GenericTypes.IntrinsicBoreElement<TreeItemProps, void>;
+    }
+  }
+}


### PR DESCRIPTION
affects: @blaze-elements/tree

Closes #278

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
