### PR TITLE
fix(common): returned value for babel causes error

### DIFF
--- a/packages/common/decorators.ts
+++ b/packages/common/decorators.ts
@@ -37,7 +37,6 @@ const identityFn = <T>( _: T ) => _;
 
 export function prop( config: PropConfig = {} ): PropertyDecorator {
   return function( targetProto: { [ key: string ]: any } & Component<any>, propertyKey: string | symbol ) {
-    const currentValue = targetProto[ propertyKey ];
     const { type, ...skPropConfig } = config;
     const configType = parseType( type );
     const skatePropTypeFn = skProp[ configType ] || identityFn;
@@ -60,7 +59,7 @@ export function prop( config: PropConfig = {} ): PropertyDecorator {
     return {
       enumerable: true,
       configurable: true,
-      value: currentValue,
+      // value: targetProto[ propertyKey ], // value causes error with private properties (title, disabled) and in IE
     };
   };
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
@prop does not work with private properties


**What is the new behavior?**
@prop works with private properties, but there is still issue with `babel`


**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
Babel compiler from now does not work properly with blaze-elements

**Other information**:

affects: @blaze-elements/common

Closes #284