### PR TITLE
fix(input): add title binding via @prop decorator

### DIFF
--- a/packages/input/Input.test.tsx
+++ b/packages/input/Input.test.tsx
@@ -1,4 +1,4 @@
-import { mount, h } from 'bore';
+import { mount, h, WrappedNode } from 'bore';
 import * as expect from 'expect';
 import { Input } from './index';
 import { emit } from 'skatejs';
@@ -125,13 +125,21 @@ describe( Input.is, () => {
 
         return mount(
           <bl-input disabled value="" />
-        ).wait(( element ) => {
-
-          expect( element.one( 'input' ).node.hasAttribute( 'disabled' ) ).toBe( true );
-
-        } );
+        ).wait(checkDisabled);
 
       } );
+
+      it( `should render disabled via attr`, () => {
+
+        return mount(
+          <bl-input attrs={{disabled: true, value: 'value'}} />
+        ).wait(checkDisabled);
+
+      } );
+
+      function checkDisabled( element: WrappedNode ) {
+        expect( element.one( 'input' ).node.hasAttribute( 'disabled' ) ).toBe( true );
+      }
 
     } );
 

--- a/packages/input/Input.tsx
+++ b/packages/input/Input.tsx
@@ -32,7 +32,7 @@ export type Events = {
   change?: GenericEvents.CustomChangeHandler<string>,
 };
 export type Props = {
-  value: string,
+  value?: string,
   valid?: string,
   placeholder?: string,
   disabled?: boolean | null,
@@ -50,9 +50,7 @@ export default class Input extends Component<InputProps> {
   @prop( { type: String, attribute: { source: true } } ) type = 'text';
   @prop( { type: String, attribute: { source: true } } ) inputSize: Size;
   @prop( { type: String, attribute: { source: true } } ) valid: string;
-  // @prop( { type: Boolean, attribute: { source: true } } ) disabled: boolean;
-
-  disabled: boolean | null = null;
+  @prop( { type: Boolean, attribute: { source: true } } ) disabled: boolean;
 
   static get events() {
     return {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/wc-catalogue/blaze-elements/blob/master/docs/CONTRIBUTING.md#commit
- [x] There are no linting errors and code is properly formatted (your run before push `yarn ts:format && yarn ts:lint:fix`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Title does not bind via decorator


**What is the new behavior?**
Title binds via @prop decorator



**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: 
Title from now is binded via attribute, not only via prop


**Other information**:
affects: @blaze-elements/input

Closes #287
